### PR TITLE
Add Phase 1 implementation specification documents

### DIFF
--- a/spec/phase-1/01-project-setup.md
+++ b/spec/phase-1/01-project-setup.md
@@ -1,0 +1,202 @@
+# 01: プロジェクトセットアップ
+
+## 目的
+
+開発環境を整備し、プロジェクトの骨格を作成する。
+
+---
+
+## 実装するファイル
+
+| ファイル | 説明 |
+|---------|------|
+| `pyproject.toml` | プロジェクト設定・依存関係 |
+| `src/myao2/__init__.py` | パッケージ初期化 |
+| `src/myao2/__main__.py` | エントリポイント |
+| 各層の `__init__.py` | サブパッケージ初期化 |
+| `.github/workflows/ci.yml` | CI ワークフロー（lint + test） |
+
+---
+
+## pyproject.toml
+
+### 依存関係
+
+| パッケージ | 用途 |
+|-----------|------|
+| `slack-bolt` | Slack Bot フレームワーク |
+| `litellm` | LLM API ラッパー |
+| `pyyaml` | YAML パーサー |
+
+### 開発依存関係
+
+| パッケージ | 用途 |
+|-----------|------|
+| `pytest` | テストフレームワーク |
+| `pytest-asyncio` | 非同期テストサポート |
+| `ruff` | Linter / Formatter |
+| `ty` | 型チェッカー |
+
+### tool.ruff 設定
+
+- `line-length`: 88
+- `target-version`: "py312"
+- `select`: ["E", "F", "I", "W"]（基本的なルール）
+
+---
+
+## ディレクトリ構造
+
+```
+myao2/
+├── .github/
+│   └── workflows/
+│       └── ci.yml           # CI ワークフロー
+├── pyproject.toml
+├── config.yaml.example      # 設定ファイルサンプル
+├── src/
+│   └── myao2/
+│       ├── __init__.py
+│       ├── __main__.py
+│       ├── config/
+│       │   └── __init__.py
+│       ├── domain/
+│       │   ├── __init__.py
+│       │   ├── entities/
+│       │   │   └── __init__.py
+│       │   └── services/
+│       │       └── __init__.py
+│       ├── application/
+│       │   ├── __init__.py
+│       │   └── use_cases/
+│       │       └── __init__.py
+│       ├── infrastructure/
+│       │   ├── __init__.py
+│       │   ├── slack/
+│       │   │   └── __init__.py
+│       │   └── llm/
+│       │       └── __init__.py
+│       └── presentation/
+│           └── __init__.py
+└── tests/
+    ├── __init__.py
+    └── conftest.py
+```
+
+---
+
+## GitHub Actions（CI）
+
+### `.github/workflows/ci.yml`
+
+PR および main ブランチへのプッシュ時に自動実行される CI ワークフロー。
+
+#### トリガー
+
+- `push`: main ブランチ
+- `pull_request`: main ブランチへのPR
+
+#### ジョブ構成
+
+| ジョブ | 内容 |
+|-------|------|
+| `lint` | ruff check, ruff format --check, ty check |
+| `test` | pytest 実行 |
+
+#### 使用するアクション
+
+| アクション | 用途 |
+|-----------|------|
+| `actions/checkout@v4` | リポジトリのチェックアウト |
+| `astral-sh/setup-uv@v4` | uv のセットアップ |
+
+#### ワークフロー設計
+
+```
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+      - run: uv run ty check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync
+      - run: uv run pytest
+```
+
+---
+
+## インターフェース設計
+
+### `src/myao2/__init__.py`
+
+```
+"""myao2 - Slack上で友達のように振る舞うチャットボット"""
+
+__version__ = "0.1.0"
+```
+
+### `src/myao2/__main__.py`
+
+```
+"""アプリケーションのエントリポイント"""
+
+def main() -> None:
+    """アプリケーションを起動する"""
+    ...
+
+if __name__ == "__main__":
+    main()
+```
+
+- Phase 1 完了時には、設定読み込み→Slackアプリ起動の流れを実装
+- 初期段階では空の `main()` 関数でOK
+
+---
+
+## テストケース
+
+### 環境構築の検証
+
+| テスト | 期待結果 |
+|--------|---------|
+| `uv sync` | 依存関係がエラーなくインストールされる |
+| `uv run ruff check .` | エラーが0件 |
+| `uv run ruff format --check .` | フォーマット差分が0件 |
+| `uv run ty check` | 型エラーが0件 |
+| `uv run pytest` | テストが実行される（0件でもOK） |
+
+### モジュールインポートの検証
+
+| テスト | 期待結果 |
+|--------|---------|
+| `python -c "import myao2"` | エラーなくインポートできる |
+| `python -c "from myao2 import __version__"` | バージョン文字列が取得できる |
+
+---
+
+## 完了基準
+
+- [ ] `pyproject.toml` が作成され、`uv sync` が成功する
+- [ ] すべての `__init__.py` が作成されている
+- [ ] `uv run ruff check .` がエラー0件で通過
+- [ ] `uv run ty check` がエラー0件で通過
+- [ ] `uv run python -c "import myao2"` が成功する
+- [ ] GitHub Actions の CI が正常に動作する（lint + test）

--- a/spec/phase-1/02-config-foundation.md
+++ b/spec/phase-1/02-config-foundation.md
@@ -1,0 +1,194 @@
+# 02: 設定ファイル基盤
+
+## 目的
+
+config.yaml の読み込みと環境変数展開を実装する。
+
+---
+
+## 実装するファイル
+
+| ファイル | 説明 |
+|---------|------|
+| `src/myao2/config/loader.py` | YAML 読み込み・環境変数展開 |
+| `src/myao2/config/models.py` | 設定データクラス |
+| `tests/config/test_loader.py` | ローダーのテスト |
+
+---
+
+## 設定ファイル形式
+
+```yaml
+# config.yaml
+slack:
+  bot_token: ${SLACK_BOT_TOKEN}
+  app_token: ${SLACK_APP_TOKEN}
+
+llm:
+  default:
+    model: "gpt-4o"
+    temperature: 0.7
+    max_tokens: 1000
+
+persona:
+  name: "myao"
+  system_prompt: "あなたは友達のように振る舞うチャットボットです。"
+```
+
+---
+
+## インターフェース設計
+
+### `src/myao2/config/models.py`
+
+#### SlackConfig
+
+```
+@dataclass
+class SlackConfig:
+    """Slack接続設定"""
+    bot_token: str
+    app_token: str
+```
+
+#### LLMConfig
+
+```
+@dataclass
+class LLMConfig:
+    """LLM設定（LiteLLMのcompletionに渡すdict）"""
+    model: str
+    temperature: float = 0.7
+    max_tokens: int = 1000
+    # 追加パラメータは **kwargs で対応
+```
+
+#### PersonaConfig
+
+```
+@dataclass
+class PersonaConfig:
+    """ペルソナ設定"""
+    name: str
+    system_prompt: str
+```
+
+#### Config
+
+```
+@dataclass
+class Config:
+    """アプリケーション設定"""
+    slack: SlackConfig
+    llm: dict[str, LLMConfig]  # "default", "judgment" 等のキー
+    persona: PersonaConfig
+```
+
+### `src/myao2/config/loader.py`
+
+#### load_config
+
+```
+def load_config(path: str | Path) -> Config:
+    """設定ファイルを読み込む
+
+    Args:
+        path: config.yaml のパス
+
+    Returns:
+        Config オブジェクト
+
+    Raises:
+        FileNotFoundError: ファイルが存在しない
+        ConfigValidationError: 必須項目が欠落
+        EnvironmentVariableError: 環境変数が未設定
+    """
+```
+
+#### expand_env_vars
+
+```
+def expand_env_vars(value: str) -> str:
+    """文字列中の ${VAR_NAME} を環境変数の値に置換する
+
+    Args:
+        value: 置換対象の文字列
+
+    Returns:
+        環境変数が展開された文字列
+
+    Raises:
+        EnvironmentVariableError: 環境変数が未設定
+    """
+```
+
+### 例外クラス
+
+```
+class ConfigError(Exception):
+    """設定関連の基底例外"""
+
+class ConfigValidationError(ConfigError):
+    """設定値のバリデーションエラー"""
+
+class EnvironmentVariableError(ConfigError):
+    """環境変数が見つからないエラー"""
+```
+
+---
+
+## テストケース
+
+### test_loader.py
+
+#### 正常系
+
+| テスト | 入力 | 期待結果 |
+|--------|-----|---------|
+| 正常な設定ファイル読み込み | 有効なconfig.yaml | Configオブジェクトが返る |
+| 環境変数の展開 | `${EXISTING_VAR}` | 環境変数の値に置換される |
+| 複数のLLM設定 | default, judgment | dict[str, LLMConfig]で取得できる |
+
+#### 異常系
+
+| テスト | 入力 | 期待結果 |
+|--------|-----|---------|
+| ファイルが存在しない | 存在しないパス | FileNotFoundError |
+| 環境変数が未設定 | `${UNDEFINED_VAR}` | EnvironmentVariableError |
+| 必須項目の欠落 | slack.bot_tokenなし | ConfigValidationError |
+| YAMLの構文エラー | 不正なYAML | yaml.YAMLError |
+
+#### expand_env_vars
+
+| テスト | 入力 | 期待結果 |
+|--------|-----|---------|
+| 単一の変数 | `${HOME}` | `/home/user` 等 |
+| 複数の変数 | `${A}_${B}` | `valueA_valueB` |
+| 変数なし | `plain text` | `plain text`（そのまま） |
+| 未設定の変数 | `${UNDEFINED}` | EnvironmentVariableError |
+
+---
+
+## 設計上の考慮事項
+
+### 環境変数展開の仕様
+
+- `${VAR_NAME}` 形式のみサポート
+- ネストした値も再帰的に展開
+- 未設定の環境変数は即座にエラー（デフォルト値は設けない）
+
+### LLM設定の柔軟性
+
+- `llm.default` は必須
+- 追加設定（`llm.judgment` 等）は任意
+- 各設定はLiteLLMの `completion()` にそのまま渡せる形式
+
+---
+
+## 完了基準
+
+- [ ] `load_config()` が正常な設定ファイルを読み込める
+- [ ] `${VAR_NAME}` 形式の環境変数が展開される
+- [ ] 必須項目が欠落している場合にエラーが発生する
+- [ ] 未設定の環境変数参照時にエラーが発生する
+- [ ] 全テストケースが通過する

--- a/spec/phase-1/03-clean-architecture.md
+++ b/spec/phase-1/03-clean-architecture.md
@@ -1,0 +1,242 @@
+# 03: クリーンアーキテクチャ基本構造
+
+## 目的
+
+各層の基本インターフェースとエンティティを定義する。
+
+---
+
+## レイヤー構成
+
+```
+┌─────────────────────────────────────────┐
+│           Presentation層                 │
+│         (Slackイベントハンドラ)           │
+└─────────────────┬───────────────────────┘
+                  │ 依存
+┌─────────────────▼───────────────────────┐
+│           Application層                  │
+│            (ユースケース)                 │
+└─────────────────┬───────────────────────┘
+                  │ 依存
+┌─────────────────▼───────────────────────┐
+│            Domain層                      │
+│     (エンティティ, Protocol)              │
+└─────────────────────────────────────────┘
+                  ▲
+                  │ 実装
+┌─────────────────┴───────────────────────┐
+│         Infrastructure層                 │
+│       (Slack, LLM, 永続化)               │
+└─────────────────────────────────────────┘
+```
+
+**依存ルール**:
+- Domain層は他の層に依存しない
+- Application層はDomain層にのみ依存
+- Infrastructure層はDomain層のProtocolを実装
+- Presentation層はApplication層に依存
+
+---
+
+## 実装するファイル
+
+### Domain層
+
+| ファイル | 説明 |
+|---------|------|
+| `src/myao2/domain/entities/message.py` | Message エンティティ |
+| `src/myao2/domain/entities/user.py` | User エンティティ |
+| `src/myao2/domain/entities/channel.py` | Channel エンティティ |
+| `src/myao2/domain/services/protocols.py` | サービスインターフェース |
+
+### Application層
+
+| ファイル | 説明 |
+|---------|------|
+| `src/myao2/application/use_cases/reply_to_mention.py` | メンション応答ユースケース |
+
+### テスト
+
+| ファイル | 説明 |
+|---------|------|
+| `tests/domain/entities/test_message.py` | Message のテスト |
+| `tests/application/use_cases/test_reply_to_mention.py` | ユースケースのテスト |
+
+---
+
+## インターフェース設計
+
+### Domain層 - エンティティ
+
+#### User
+
+```
+@dataclass(frozen=True)
+class User:
+    """ユーザーエンティティ（プラットフォーム非依存）"""
+    id: str           # プラットフォーム固有のID
+    name: str         # 表示名
+    is_bot: bool = False
+```
+
+#### Channel
+
+```
+@dataclass(frozen=True)
+class Channel:
+    """チャンネルエンティティ"""
+    id: str
+    name: str
+```
+
+#### Message
+
+```
+@dataclass(frozen=True)
+class Message:
+    """メッセージエンティティ"""
+    id: str
+    channel: Channel
+    user: User
+    text: str
+    timestamp: datetime
+    thread_ts: str | None = None  # スレッドの親メッセージ
+    mentions: list[str] = field(default_factory=list)  # メンションされたユーザーID
+
+    def is_in_thread(self) -> bool:
+        """スレッド内のメッセージかどうか"""
+        ...
+
+    def mentions_user(self, user_id: str) -> bool:
+        """指定ユーザーがメンションされているか"""
+        ...
+```
+
+### Domain層 - Protocol
+
+#### MessagingService
+
+```
+class MessagingService(Protocol):
+    """メッセージング抽象（プラットフォーム非依存）"""
+
+    def send_message(
+        self,
+        channel_id: str,
+        text: str,
+        thread_ts: str | None = None
+    ) -> None:
+        """メッセージを送信する"""
+        ...
+```
+
+#### ResponseGenerator
+
+```
+class ResponseGenerator(Protocol):
+    """応答生成抽象"""
+
+    def generate(
+        self,
+        user_message: str,
+        system_prompt: str
+    ) -> str:
+        """応答を生成する"""
+        ...
+```
+
+### Application層 - ユースケース
+
+#### ReplyToMentionUseCase
+
+```
+class ReplyToMentionUseCase:
+    """メンションへの応答ユースケース"""
+
+    def __init__(
+        self,
+        messaging_service: MessagingService,
+        response_generator: ResponseGenerator,
+        persona: PersonaConfig,
+        bot_user_id: str
+    ) -> None:
+        """
+        Args:
+            messaging_service: メッセージ送信サービス
+            response_generator: 応答生成サービス
+            persona: ペルソナ設定
+            bot_user_id: ボット自身のユーザーID
+        """
+        ...
+
+    def execute(self, message: Message) -> None:
+        """メンションに応答する
+
+        Args:
+            message: 受信したメッセージ
+
+        Note:
+            - ボット自身へのメンションが含まれている場合のみ応答
+            - スレッドがある場合はスレッドに返信
+        """
+        ...
+```
+
+---
+
+## テストケース
+
+### test_message.py
+
+#### Messageエンティティ
+
+| テスト | 入力 | 期待結果 |
+|--------|-----|---------|
+| 基本的な生成 | 必須フィールド | Messageオブジェクトが生成される |
+| is_in_thread（スレッド内） | thread_ts="xxx" | True |
+| is_in_thread（チャンネル直下） | thread_ts=None | False |
+| mentions_user（メンションあり） | mentions=["U123"], user_id="U123" | True |
+| mentions_user（メンションなし） | mentions=["U123"], user_id="U456" | False |
+
+### test_reply_to_mention.py
+
+#### ReplyToMentionUseCase
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| メンションあり・チャンネル | ボットがメンションされた | チャンネルにメッセージ送信 |
+| メンションあり・スレッド | スレッド内でメンション | スレッドに返信 |
+| メンションなし | 他ユーザーのみメンション | 何もしない |
+| ボット自身のメッセージ | ボットが送信者 | 何もしない |
+
+---
+
+## 設計上の考慮事項
+
+### プラットフォーム非依存
+
+- Domainエンティティは Slack 固有の概念を持たない
+- `Message.id` はプラットフォーム固有のIDを受け入れる
+- 将来 Discord 等に対応する際も Domain層は変更不要
+
+### イミュータブル設計
+
+- エンティティは `frozen=True` で不変
+- 状態変更が必要な場合は新しいインスタンスを生成
+
+### Protocol の使用
+
+- Python 3.8+ の `typing.Protocol` を使用
+- 構造的部分型によるダックタイピング
+- テスト時のモック作成が容易
+
+---
+
+## 完了基準
+
+- [ ] Message, User, Channel エンティティが実装されている
+- [ ] MessagingService, ResponseGenerator Protocol が定義されている
+- [ ] ReplyToMentionUseCase が実装されている
+- [ ] エンティティの各メソッドがテストされている
+- [ ] ユースケースがモックを使ってテストされている

--- a/spec/phase-1/04-slack-integration.md
+++ b/spec/phase-1/04-slack-integration.md
@@ -1,0 +1,258 @@
+# 04: Slack連携
+
+## 目的
+
+Slack Bolt を使ったメッセージ受信・送信を実装する。
+
+---
+
+## 実装するファイル
+
+| ファイル | 説明 |
+|---------|------|
+| `src/myao2/infrastructure/slack/client.py` | Bolt アプリケーション設定 |
+| `src/myao2/infrastructure/slack/messaging.py` | MessagingService 実装 |
+| `src/myao2/infrastructure/slack/event_adapter.py` | Slackイベント→Domainエンティティ変換 |
+| `src/myao2/presentation/slack_handlers.py` | イベントハンドラ |
+| `tests/infrastructure/slack/test_messaging.py` | メッセージングのテスト |
+| `tests/infrastructure/slack/test_event_adapter.py` | アダプターのテスト |
+
+---
+
+## Slack Bolt の設定
+
+### Socket Mode
+
+- WebSocket による接続（HTTPエンドポイント不要）
+- App-Level Token（`xapp-...`）を使用
+- 開発環境でもローカルで動作可能
+
+### 必要なスコープ
+
+| スコープ | 用途 |
+|---------|------|
+| `app_mentions:read` | メンションイベントの受信 |
+| `chat:write` | メッセージの送信 |
+| `channels:history` | チャンネル履歴の読み取り（Phase 2以降で使用） |
+| `users:read` | ユーザー情報の取得 |
+
+### イベント購読
+
+| イベント | 用途 |
+|---------|------|
+| `app_mention` | ボットがメンションされた時 |
+
+---
+
+## インターフェース設計
+
+### `src/myao2/infrastructure/slack/client.py`
+
+#### create_slack_app
+
+```
+def create_slack_app(config: SlackConfig) -> App:
+    """Slack Bolt アプリケーションを生成する
+
+    Args:
+        config: Slack接続設定
+
+    Returns:
+        設定済みの Bolt App インスタンス
+    """
+```
+
+#### SlackAppRunner
+
+```
+class SlackAppRunner:
+    """Slack アプリケーションの実行管理"""
+
+    def __init__(self, app: App, app_token: str) -> None:
+        """
+        Args:
+            app: Bolt App インスタンス
+            app_token: App-Level Token
+        """
+        ...
+
+    def start(self) -> None:
+        """Socket Mode でアプリを起動する（ブロッキング）"""
+        ...
+
+    def stop(self) -> None:
+        """アプリを停止する"""
+        ...
+```
+
+### `src/myao2/infrastructure/slack/messaging.py`
+
+#### SlackMessagingService
+
+```
+class SlackMessagingService:
+    """Slack用 MessagingService 実装"""
+
+    def __init__(self, client: WebClient) -> None:
+        """
+        Args:
+            client: Slack WebClient
+        """
+        ...
+
+    def send_message(
+        self,
+        channel_id: str,
+        text: str,
+        thread_ts: str | None = None
+    ) -> None:
+        """メッセージを送信する
+
+        Args:
+            channel_id: 送信先チャンネルID
+            text: メッセージ本文
+            thread_ts: スレッドの親タイムスタンプ（スレッド返信時）
+
+        Raises:
+            SlackApiError: Slack API エラー
+        """
+        ...
+
+    def get_bot_user_id(self) -> str:
+        """ボット自身のユーザーIDを取得する"""
+        ...
+```
+
+### `src/myao2/infrastructure/slack/event_adapter.py`
+
+#### SlackEventAdapter
+
+```
+class SlackEventAdapter:
+    """Slackイベントを Domain エンティティに変換"""
+
+    def __init__(self, client: WebClient) -> None:
+        """
+        Args:
+            client: ユーザー情報取得用 WebClient
+        """
+        ...
+
+    def to_message(self, event: dict) -> Message:
+        """Slackイベントを Message エンティティに変換
+
+        Args:
+            event: Slack の app_mention イベント
+
+        Returns:
+            Message エンティティ
+        """
+        ...
+
+    def extract_mentions(self, text: str) -> list[str]:
+        """テキストからメンションを抽出
+
+        Args:
+            text: メッセージ本文
+
+        Returns:
+            メンションされたユーザーIDのリスト
+        """
+        ...
+```
+
+### `src/myao2/presentation/slack_handlers.py`
+
+#### register_handlers
+
+```
+def register_handlers(
+    app: App,
+    reply_use_case: ReplyToMentionUseCase,
+    event_adapter: SlackEventAdapter
+) -> None:
+    """Slack イベントハンドラを登録する
+
+    Args:
+        app: Bolt App
+        reply_use_case: メンション応答ユースケース
+        event_adapter: イベント変換アダプター
+    """
+```
+
+---
+
+## Slackイベント形式
+
+### app_mention イベント
+
+```json
+{
+    "type": "app_mention",
+    "user": "U123456",
+    "text": "<@U_BOT_ID> こんにちは",
+    "ts": "1234567890.123456",
+    "channel": "C123456",
+    "thread_ts": "1234567890.000000"  // スレッドの場合
+}
+```
+
+### メンション形式
+
+- `<@U123456>` - ユーザーメンション
+- 正規表現: `<@([A-Z0-9]+)>`
+
+---
+
+## テストケース
+
+### test_messaging.py
+
+#### SlackMessagingService
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| チャンネルへの送信 | thread_ts=None | chat.postMessage が呼ばれる |
+| スレッドへの送信 | thread_ts指定 | thread_ts付きで送信 |
+| API エラー | SlackApiError発生 | 例外が伝播する |
+
+### test_event_adapter.py
+
+#### SlackEventAdapter
+
+| テスト | 入力 | 期待結果 |
+|--------|-----|---------|
+| 基本的な変換 | app_mentionイベント | Messageエンティティ |
+| スレッド内メッセージ | thread_ts付きイベント | thread_tsが設定される |
+| メンション抽出 | `<@U123> <@U456>` | ["U123", "U456"] |
+| メンションなし | `hello` | [] |
+
+---
+
+## 設計上の考慮事項
+
+### エラーハンドリング
+
+- Slack API エラーはログに記録
+- 一時的なエラー（Rate Limit等）は再試行を検討（Phase 1では基本実装のみ）
+
+### ユーザー情報のキャッシュ
+
+- Phase 1 では都度 API を呼び出す
+- Phase 2 以降でキャッシュを検討
+
+### ボットの自己認識
+
+- `auth.test` API でボット自身のユーザーIDを取得
+- 起動時に一度だけ取得してキャッシュ
+
+---
+
+## 完了基準
+
+- [ ] Socket Mode でアプリが起動できる
+- [ ] app_mention イベントを受信できる
+- [ ] Slackイベントが Message エンティティに変換される
+- [ ] メッセージを送信できる
+- [ ] スレッドへの返信ができる
+- [ ] 全テストケースが通過する

--- a/spec/phase-1/05-llm-response.md
+++ b/spec/phase-1/05-llm-response.md
@@ -1,0 +1,237 @@
+# 05: LLM応答
+
+## 目的
+
+LiteLLM を使った応答生成を実装する。
+
+---
+
+## 実装するファイル
+
+| ファイル | 説明 |
+|---------|------|
+| `src/myao2/infrastructure/llm/client.py` | LiteLLM ラッパー |
+| `src/myao2/infrastructure/llm/response_generator.py` | ResponseGenerator 実装 |
+| `tests/infrastructure/llm/test_client.py` | LLMクライアントのテスト |
+| `tests/infrastructure/llm/test_response_generator.py` | 応答生成のテスト |
+
+---
+
+## LiteLLM の使用
+
+### 基本的な使い方
+
+LiteLLM は OpenAI API 互換のインターフェースで複数のLLMプロバイダーを抽象化する。
+
+```python
+from litellm import completion
+
+response = completion(
+    model="gpt-4o",
+    messages=[
+        {"role": "system", "content": "..."},
+        {"role": "user", "content": "..."}
+    ],
+    temperature=0.7,
+    max_tokens=1000
+)
+```
+
+### 設定の適用
+
+`config.yaml` の `llm.default` セクションがそのまま `completion()` に渡される。
+
+---
+
+## インターフェース設計
+
+### `src/myao2/infrastructure/llm/client.py`
+
+#### LLMClient
+
+```
+class LLMClient:
+    """LiteLLM ラッパー"""
+
+    def __init__(self, config: LLMConfig) -> None:
+        """
+        Args:
+            config: LLM設定（model, temperature, max_tokens等）
+        """
+        ...
+
+    def complete(
+        self,
+        messages: list[dict[str, str]],
+        **kwargs: Any
+    ) -> str:
+        """チャット補完を実行する
+
+        Args:
+            messages: OpenAI形式のメッセージリスト
+                [{"role": "system", "content": "..."}, ...]
+            **kwargs: 追加パラメータ（設定を上書き）
+
+        Returns:
+            生成されたテキスト
+
+        Raises:
+            LLMError: API呼び出しエラー
+        """
+        ...
+```
+
+#### 例外クラス
+
+```
+class LLMError(Exception):
+    """LLM関連のエラー"""
+
+class LLMRateLimitError(LLMError):
+    """レート制限エラー"""
+
+class LLMAuthenticationError(LLMError):
+    """認証エラー"""
+```
+
+### `src/myao2/infrastructure/llm/response_generator.py`
+
+#### LiteLLMResponseGenerator
+
+```
+class LiteLLMResponseGenerator:
+    """LiteLLMを使った ResponseGenerator 実装"""
+
+    def __init__(self, client: LLMClient) -> None:
+        """
+        Args:
+            client: LLMClient インスタンス
+        """
+        ...
+
+    def generate(
+        self,
+        user_message: str,
+        system_prompt: str
+    ) -> str:
+        """応答を生成する
+
+        Args:
+            user_message: ユーザーからのメッセージ
+            system_prompt: システムプロンプト（ペルソナ設定等）
+
+        Returns:
+            生成された応答テキスト
+
+        Raises:
+            LLMError: 応答生成に失敗
+        """
+        ...
+```
+
+---
+
+## メッセージ形式
+
+### 基本的な構造
+
+```python
+messages = [
+    {
+        "role": "system",
+        "content": persona.system_prompt
+    },
+    {
+        "role": "user",
+        "content": user_message
+    }
+]
+```
+
+### Phase 1 での制限
+
+- 会話履歴は含めない（単発の応答）
+- コンテキストは Phase 2 以降で追加
+
+---
+
+## テストケース
+
+### test_client.py
+
+#### LLMClient
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 正常な補完 | 有効なメッセージ | 応答テキストが返る |
+| 設定の適用 | temperature=0.5 | パラメータが反映される |
+| kwargsによる上書き | max_tokens=500 | 設定が上書きされる |
+| 認証エラー | 無効なAPIキー | LLMAuthenticationError |
+| レート制限 | 429エラー | LLMRateLimitError |
+
+### test_response_generator.py
+
+#### LiteLLMResponseGenerator
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 基本的な生成 | user_message + system_prompt | 応答が生成される |
+| システムプロンプトの適用 | ペルソナ設定 | プロンプトがmessagesに含まれる |
+| 空のメッセージ | user_message="" | 応答が生成される（または適切なエラー） |
+| LLMエラーの伝播 | client がエラー | LLMError が伝播 |
+
+---
+
+## テストでのモック
+
+### LiteLLMのモック
+
+```python
+@pytest.fixture
+def mock_completion(mocker):
+    return mocker.patch("litellm.completion")
+
+def test_complete_success(mock_completion, llm_client):
+    mock_completion.return_value = MockResponse(
+        choices=[MockChoice(message=MockMessage(content="Hello!"))]
+    )
+
+    result = llm_client.complete([{"role": "user", "content": "Hi"}])
+
+    assert result == "Hello!"
+```
+
+### 統合テスト用の設定
+
+- 環境変数 `TEST_WITH_REAL_LLM=true` で実際のAPIを使用
+- デフォルトはモックを使用（API課金なし）
+
+---
+
+## 設計上の考慮事項
+
+### エラーハンドリング
+
+- LiteLLM の例外をキャッチしてドメイン例外に変換
+- レート制限時のリトライは Phase 1 では実装しない
+
+### ログ記録
+
+- APIリクエスト/レスポンスをデバッグログに記録
+- 本番環境ではプロンプト内容を記録しない（プライバシー考慮）
+
+### 環境変数
+
+- LLM APIキーは環境変数で設定（`OPENAI_API_KEY` 等）
+- LiteLLM が自動的に読み取る
+
+---
+
+## 完了基準
+
+- [ ] LLMClient が LiteLLM を正しく呼び出せる
+- [ ] 設定ファイルのパラメータが適用される
+- [ ] LiteLLMResponseGenerator が応答を生成できる
+- [ ] システムプロンプト（ペルソナ）が適用される
+- [ ] エラーが適切な例外クラスで伝播する
+- [ ] 全テストケースが通過する（モック使用）

--- a/spec/phase-1/README.md
+++ b/spec/phase-1/README.md
@@ -1,0 +1,216 @@
+# Phase 1: 基盤構築 - 実装手順書
+
+## 目標
+
+プロジェクトの基盤を構築し、最小限のSlack連携とLLM応答を実現する。
+
+## 成果物
+
+メンションに応答できるシンプルなボット
+
+- `uv run python -m myao2` で起動
+- Slackでボットをメンションすると、LLMが生成した応答を返信
+
+---
+
+## 前提条件
+
+### 開発環境
+
+- Python 3.12+
+- uv（パッケージマネージャー）
+
+### Slackアプリ設定
+
+1. Slack App を作成（https://api.slack.com/apps）
+2. Socket Mode を有効化
+3. 必要なスコープを設定:
+   - `app_mentions:read` - メンションの読み取り
+   - `chat:write` - メッセージの送信
+   - `channels:history` - チャンネル履歴の読み取り
+4. App-Level Token を取得（`connections:write` スコープ）
+5. Bot Token を取得
+
+### 環境変数
+
+- `SLACK_BOT_TOKEN` - Bot User OAuth Token
+- `SLACK_APP_TOKEN` - App-Level Token（Socket Mode用）
+
+---
+
+## タスク一覧
+
+| # | タスク | 詳細設計書 | 依存 |
+|---|--------|-----------|------|
+| 01 | プロジェクトセットアップ | [01-project-setup.md](./01-project-setup.md) | - |
+| 02 | 設定ファイル基盤 | [02-config-foundation.md](./02-config-foundation.md) | 01 |
+| 03 | クリーンアーキテクチャ基本構造 | [03-clean-architecture.md](./03-clean-architecture.md) | 02 |
+| 04 | Slack連携 | [04-slack-integration.md](./04-slack-integration.md) | 03 |
+| 05 | LLM応答 | [05-llm-response.md](./05-llm-response.md) | 03 |
+
+---
+
+## 実装順序
+
+```
+[01] プロジェクトセットアップ
+        ↓
+[02] 設定ファイル基盤
+        ↓
+[03] クリーンアーキテクチャ基本構造
+        ↓
+    ┌───┴───┐
+    ↓       ↓
+[04]     [05]
+Slack    LLM
+連携     応答
+    └───┬───┘
+        ↓
+    統合・動作確認
+```
+
+---
+
+## タスク概要
+
+### 01: プロジェクトセットアップ
+
+開発環境を整備し、プロジェクトの骨格を作成する。
+
+- pyproject.toml の作成
+- ディレクトリ構造の作成
+- ruff, ty の設定
+- エントリポイントの作成
+
+### 02: 設定ファイル基盤
+
+config.yaml の読み込みと環境変数展開を実装する。
+
+- YAML ファイルの読み込み
+- `${VAR_NAME}` 形式の環境変数展開
+- 設定値のバリデーション
+- 型安全な設定アクセス
+
+### 03: クリーンアーキテクチャ基本構造
+
+各層の基本インターフェースとエンティティを定義する。
+
+- Domain層: Message, User, Channel エンティティ
+- Application層: ReplyToMentionUseCase
+- Infrastructure層: 各Protocolの実装スタブ
+- Presentation層: イベントハンドラ基本構造
+
+### 04: Slack連携
+
+Slack Bolt を使ったメッセージ受信・送信を実装する。
+
+- Socket Mode によるイベント受信
+- メッセージ送信機能
+- メンション検出
+
+### 05: LLM応答
+
+LiteLLM を使った応答生成を実装する。
+
+- LiteLLM ラッパー
+- ペルソナ設定の適用
+- 応答生成
+
+---
+
+## Phase 1 完了の検証方法
+
+### 自動テスト
+
+```bash
+# 全テストの実行
+uv run pytest
+
+# Linter
+uv run ruff check .
+
+# 型チェック
+uv run ty check
+```
+
+### 手動検証
+
+1. 環境変数を設定
+
+```bash
+export SLACK_BOT_TOKEN=xoxb-...
+export SLACK_APP_TOKEN=xapp-...
+```
+
+2. アプリケーションを起動
+
+```bash
+uv run python -m myao2
+```
+
+3. Slackでボットをメンション
+
+```
+@myao2 こんにちは
+```
+
+4. ボットが応答を返すことを確認
+
+---
+
+## ディレクトリ構造（Phase 1 完了時）
+
+```
+src/myao2/
+├── __init__.py
+├── __main__.py              # エントリポイント
+├── config/
+│   ├── __init__.py
+│   ├── loader.py            # 設定読み込み
+│   └── models.py            # 設定データクラス
+├── domain/
+│   ├── __init__.py
+│   ├── entities/
+│   │   ├── __init__.py
+│   │   ├── message.py
+│   │   ├── user.py
+│   │   └── channel.py
+│   └── services/
+│       ├── __init__.py
+│       └── protocols.py     # MessagingService等
+├── application/
+│   ├── __init__.py
+│   └── use_cases/
+│       ├── __init__.py
+│       └── reply_to_mention.py
+├── infrastructure/
+│   ├── __init__.py
+│   ├── slack/
+│   │   ├── __init__.py
+│   │   ├── client.py        # Boltアプリ
+│   │   └── messaging.py     # MessagingService実装
+│   └── llm/
+│       ├── __init__.py
+│       ├── client.py        # LiteLLMラッパー
+│       └── response_generator.py
+└── presentation/
+    ├── __init__.py
+    └── slack_handlers.py    # イベントハンドラ
+
+tests/
+├── __init__.py
+├── conftest.py
+├── config/
+│   └── test_loader.py
+├── domain/
+│   └── entities/
+│       └── test_message.py
+├── application/
+│   └── use_cases/
+│       └── test_reply_to_mention.py
+└── infrastructure/
+    ├── slack/
+    │   └── test_messaging.py
+    └── llm/
+        └── test_client.py
+```


### PR DESCRIPTION
## Summary

Phase 1（基盤構築）の実装手順書と詳細設計書を追加しました。

### 追加したドキュメント

| ファイル | 内容 |
|---------|------|
| `spec/phase-1/README.md` | 実装手順書（目標、前提条件、タスク一覧、依存関係、検証方法） |
| `spec/phase-1/01-project-setup.md` | プロジェクトセットアップ（pyproject.toml、ディレクトリ構造） |
| `spec/phase-1/02-config-foundation.md` | 設定ファイル基盤（YAML読み込み、環境変数展開） |
| `spec/phase-1/03-clean-architecture.md` | クリーンアーキテクチャ基本構造（エンティティ、Protocol、ユースケース） |
| `spec/phase-1/04-slack-integration.md` | Slack連携（Bolt、Socket Mode、イベントハンドラ） |
| `spec/phase-1/05-llm-response.md` | LLM応答（LiteLLMラッパー、ResponseGenerator） |

### 設計方針

- **粒度**: インターフェース中心（クラス・関数シグネチャとdocstring）
- **テスト**: 各詳細設計書にテストケース一覧と期待値を含める（TDD用）
- **ソースコード**: ドキュメントには含めない

### Phase 1 の成果物

メンションに応答できるシンプルなボット

## Test plan

- [ ] 各ドキュメントが正しいMarkdown形式で記述されている
- [ ] リンク切れがない
- [ ] 実装に必要な情報が網羅されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)