### PR TITLE
Add SQLModel to tech stack documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ myao2 - Slack上で友達のように振る舞うチャットボット
 - **Linter**: ruff
 - **型チェック**: ty
 - **永続化**: SQLite
+- **ORM**: SQLModel
 
 ## 開発コマンド
 

--- a/requirements.md
+++ b/requirements.md
@@ -95,6 +95,7 @@ Slack上で誰かがコメントした時に、誰も反応しないと寂しい
 | Linter | ruff |
 | 型チェック | ty |
 | 永続化 | SQLite |
+| ORM | SQLModel |
 
 ### 4.2 アーキテクチャ
 


### PR DESCRIPTION
## Summary
- 技術スタックにSQLModelをORMとして追加
- `requirements.md` と `CLAUDE.md` を更新

## Test plan
- [ ] ドキュメントの内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)