### PR TITLE
Implement application entry point for Phase 1 manual verification

### DIFF
--- a/src/myao2/__main__.py
+++ b/src/myao2/__main__.py
@@ -61,7 +61,7 @@ def main() -> None:
         bot_user_id=bot_user_id,
     )
 
-    register_handlers(app, reply_use_case, event_adapter)
+    register_handlers(app, reply_use_case, event_adapter, bot_user_id)
 
     logger.info("Starting %s...", config.persona.name)
     runner = SlackAppRunner(app, config.slack.app_token)

--- a/src/myao2/presentation/slack_handlers.py
+++ b/src/myao2/presentation/slack_handlers.py
@@ -14,6 +14,7 @@ def register_handlers(
     app: App,
     reply_use_case: ReplyToMentionUseCase,
     event_adapter: SlackEventAdapter,
+    bot_user_id: str,
 ) -> None:
     """Register Slack event handlers.
 
@@ -21,6 +22,7 @@ def register_handlers(
         app: Bolt App instance.
         reply_use_case: Use case for replying to mentions.
         event_adapter: Adapter for converting events to entities.
+        bot_user_id: The bot's user ID.
     """
 
     @app.event("app_mention")
@@ -37,3 +39,30 @@ def register_handlers(
             reply_use_case.execute(message)
         except Exception:
             logger.exception("Error handling app_mention event")
+
+    @app.event("message")
+    def handle_message(event: dict) -> None:
+        """Handle message events.
+
+        Responds to messages that mention the bot when app_mention
+        event is not triggered.
+
+        Args:
+            event: Slack event payload.
+        """
+        # Ignore message subtypes (edits, deletes, etc.)
+        if event.get("subtype"):
+            return
+
+        # Check if bot is mentioned in the message
+        text = event.get("text", "")
+        if f"<@{bot_user_id}>" not in text:
+            return
+
+        logger.info("Received message with mention: %s", event.get("ts"))
+
+        try:
+            message = event_adapter.to_message(event)
+            reply_use_case.execute(message)
+        except Exception:
+            logger.exception("Error handling message event")


### PR DESCRIPTION
## Summary
- `__main__.py` を実装し、Phase 1 の手動検証が動作するようにした
- すべてのコンポーネント（Slack, LLM, UseCase）を組み立てて起動するようにした

## Test plan
- [x] `uv run pytest` - 全テスト通過
- [x] `uv run ruff check .` - エラーなし
- [x] `uv run ty check` - エラーなし
- [ ] 手動検証: `uv run python -m myao2` でボットが起動し、メンションに応答することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)