### PR TITLE
Add Phase 2 context management specification

### DIFF
--- a/spec/phase-2/01-sqlite-persistence.md
+++ b/spec/phase-2/01-sqlite-persistence.md
@@ -1,0 +1,275 @@
+# 01: SQLite永続化基盤
+
+## 目的
+
+SQLModel を使ったデータベース基盤を構築する。
+
+---
+
+## 実装するファイル
+
+| ファイル | 説明 |
+|---------|------|
+| `src/myao2/domain/repositories/__init__.py` | リポジトリモジュール |
+| `src/myao2/domain/repositories/message_repository.py` | MessageRepository Protocol |
+| `src/myao2/infrastructure/persistence/__init__.py` | 永続化モジュール |
+| `src/myao2/infrastructure/persistence/models.py` | SQLModel テーブル定義 |
+| `src/myao2/infrastructure/persistence/database.py` | DatabaseManager |
+| `src/myao2/config/models.py` | MemoryConfig 追加（修正） |
+| `tests/infrastructure/persistence/test_database.py` | DatabaseManager のテスト |
+
+---
+
+## テーブル設計
+
+### messages テーブル
+
+| カラム | 型 | 説明 | インデックス |
+|--------|-----|------|-------------|
+| id | INTEGER | 主キー（自動採番） | PK |
+| message_id | VARCHAR | Slack の ts | Yes |
+| channel_id | VARCHAR | チャンネル ID | Yes |
+| user_id | VARCHAR | ユーザー ID | - |
+| user_name | VARCHAR | ユーザー表示名 | - |
+| user_is_bot | BOOLEAN | ボットかどうか | - |
+| text | TEXT | メッセージ本文 | - |
+| timestamp | DATETIME | メッセージ投稿時刻 | - |
+| thread_ts | VARCHAR | スレッド親の ts（nullable） | Yes |
+| mentions | TEXT | メンションユーザー ID（JSON配列） | - |
+| created_at | DATETIME | レコード作成時刻 | - |
+
+**複合ユニーク制約**: `(message_id, channel_id)`
+
+---
+
+## インターフェース設計
+
+### `src/myao2/domain/repositories/message_repository.py`
+
+#### MessageRepository Protocol
+
+```
+class MessageRepository(Protocol):
+    """会話履歴リポジトリの抽象インターフェース
+
+    メッセージの保存・取得を抽象化し、
+    永続化層の実装詳細を隠蔽する。
+    """
+
+    def save(self, message: Message) -> None:
+        """メッセージを保存する
+
+        既存のメッセージ（同一の message_id, channel_id）が存在する場合は更新する。
+
+        Args:
+            message: 保存するメッセージ
+        """
+        ...
+
+    def find_by_channel(
+        self,
+        channel_id: str,
+        limit: int = 20,
+    ) -> list[Message]:
+        """チャンネルのメッセージ履歴を取得する
+
+        スレッドに属さないメッセージのみを取得する。
+
+        Args:
+            channel_id: チャンネル ID
+            limit: 取得する最大件数
+
+        Returns:
+            メッセージリスト（新しい順）
+        """
+        ...
+
+    def find_by_thread(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        limit: int = 20,
+    ) -> list[Message]:
+        """スレッドのメッセージ履歴を取得する
+
+        Args:
+            channel_id: チャンネル ID
+            thread_ts: スレッドの親タイムスタンプ
+            limit: 取得する最大件数
+
+        Returns:
+            メッセージリスト（新しい順）
+        """
+        ...
+
+    def find_by_id(self, message_id: str, channel_id: str) -> Message | None:
+        """ID でメッセージを検索する
+
+        Args:
+            message_id: メッセージ ID（Slack の ts）
+            channel_id: チャンネル ID
+
+        Returns:
+            メッセージ（存在しない場合は None）
+        """
+        ...
+```
+
+### `src/myao2/infrastructure/persistence/models.py`
+
+#### MessageModel
+
+```
+class MessageModel(SQLModel, table=True):
+    """メッセージテーブル"""
+
+    __tablename__ = "messages"
+
+    id: int | None = Field(default=None, primary_key=True)
+    message_id: str = Field(index=True)
+    channel_id: str = Field(index=True)
+    user_id: str
+    user_name: str
+    user_is_bot: bool = False
+    text: str
+    timestamp: datetime
+    thread_ts: str | None = Field(default=None, index=True)
+    mentions: str = ""  # JSON 形式: ["U123", "U456"]
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+    __table_args__ = (
+        UniqueConstraint("message_id", "channel_id", name="uq_message_channel"),
+    )
+```
+
+### `src/myao2/infrastructure/persistence/database.py`
+
+#### DatabaseManager
+
+```
+class DatabaseManager:
+    """データベース管理
+
+    SQLite データベースの初期化、エンジン生成、セッション管理を行う。
+    """
+
+    def __init__(self, database_path: str) -> None:
+        """初期化
+
+        Args:
+            database_path: SQLite データベースファイルのパス
+        """
+
+    def get_engine(self) -> Engine:
+        """SQLAlchemy エンジンを取得する
+
+        Returns:
+            Engine インスタンス
+        """
+
+    def create_tables(self) -> None:
+        """テーブルを作成する
+
+        既存のテーブルがある場合は何もしない。
+        """
+
+    def get_session(self) -> Session:
+        """セッションを取得する
+
+        Returns:
+            Session インスタンス
+        """
+```
+
+### `src/myao2/config/models.py`（修正）
+
+#### MemoryConfig 追加
+
+```
+@dataclass
+class MemoryConfig:
+    """記憶設定"""
+
+    database_path: str
+    long_term_update_interval_seconds: int = 3600
+
+
+@dataclass
+class Config:
+    """アプリケーション設定"""
+
+    slack: SlackConfig
+    llm: dict[str, LLMConfig]
+    persona: PersonaConfig
+    memory: MemoryConfig  # 追加
+```
+
+---
+
+## 例外クラス
+
+```
+class PersistenceError(Exception):
+    """永続化関連の基底例外"""
+
+
+class DatabaseError(PersistenceError):
+    """データベース操作エラー"""
+```
+
+---
+
+## テストケース
+
+### test_database.py
+
+#### DatabaseManager
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| エンジン生成 | 有効なパス | Engine が生成される |
+| エンジン生成（ディレクトリなし） | 親ディレクトリ未作成 | ディレクトリが作成される |
+| テーブル作成 | 初回実行 | messages テーブルが作成される |
+| テーブル作成（既存） | 2回目実行 | エラーなく完了 |
+| セッション取得 | 正常なエンジン | Session が取得できる |
+| インメモリDB | `:memory:` | 正常に動作 |
+
+---
+
+## 設計上の考慮事項
+
+### SQLModel の選択理由
+
+- SQLAlchemy のパワーと Pydantic の型安全性を兼ね備える
+- FastAPI との親和性（将来の拡張を考慮）
+- シンプルな API でボイラープレートを削減
+
+### メンションの保存形式
+
+- JSON 文字列として保存: `["U123", "U456"]`
+- シンプルで十分な柔軟性
+- 将来的に JSON カラム型に変更可能
+
+### タイムスタンプの扱い
+
+- すべて UTC で保存
+- Python の `datetime` オブジェクトを使用
+- Slack の ts（Unix timestamp 文字列）は `message_id` として保存
+
+### ディレクトリ自動作成
+
+- データベースファイルの親ディレクトリが存在しない場合は自動作成
+- `./data/memory.db` のようなパスでも問題なく動作
+
+---
+
+## 完了基準
+
+- [ ] MessageRepository Protocol が定義されている
+- [ ] MessageModel が SQLModel で定義されている
+- [ ] DatabaseManager が実装されている
+- [ ] MemoryConfig が Config に追加されている
+- [ ] データベースファイルの親ディレクトリが自動作成される
+- [ ] 全テストケースが通過する

--- a/spec/phase-2/02-message-repository.md
+++ b/spec/phase-2/02-message-repository.md
@@ -1,0 +1,325 @@
+# 02: メッセージリポジトリ実装
+
+## 目的
+
+MessageRepository の SQLite 実装を作成する。
+
+---
+
+## 実装するファイル
+
+| ファイル | 説明 |
+|---------|------|
+| `src/myao2/infrastructure/persistence/message_repository.py` | SQLiteMessageRepository |
+| `tests/infrastructure/persistence/test_message_repository.py` | リポジトリのテスト |
+
+---
+
+## 依存関係
+
+- タスク 01（SQLite永続化基盤）の完了が前提
+
+---
+
+## インターフェース設計
+
+### `src/myao2/infrastructure/persistence/message_repository.py`
+
+#### SQLiteMessageRepository
+
+```
+class SQLiteMessageRepository:
+    """SQLite 版 MessageRepository 実装
+
+    メッセージの CRUD 操作を SQLite データベースに対して行う。
+    """
+
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        """初期化
+
+        Args:
+            session_factory: セッション生成関数
+        """
+
+    def save(self, message: Message) -> None:
+        """メッセージを保存する（upsert）
+
+        既存のメッセージが存在する場合は更新する。
+
+        Args:
+            message: 保存するメッセージ
+        """
+
+    def find_by_channel(
+        self,
+        channel_id: str,
+        limit: int = 20,
+    ) -> list[Message]:
+        """チャンネルのメッセージを取得する
+
+        スレッドに属さないメッセージ（thread_ts が None）のみを取得。
+        新しい順（timestamp DESC）で返す。
+
+        Args:
+            channel_id: チャンネル ID
+            limit: 取得する最大件数
+
+        Returns:
+            メッセージリスト（新しい順）
+        """
+
+    def find_by_thread(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        limit: int = 20,
+    ) -> list[Message]:
+        """スレッドのメッセージを取得する
+
+        指定したスレッドに属するメッセージを取得。
+        新しい順（timestamp DESC）で返す。
+
+        Args:
+            channel_id: チャンネル ID
+            thread_ts: スレッドの親タイムスタンプ
+            limit: 取得する最大件数
+
+        Returns:
+            メッセージリスト（新しい順）
+        """
+
+    def find_by_id(self, message_id: str, channel_id: str) -> Message | None:
+        """ID でメッセージを検索する
+
+        Args:
+            message_id: メッセージ ID（Slack の ts）
+            channel_id: チャンネル ID
+
+        Returns:
+            メッセージ（存在しない場合は None）
+        """
+
+    def _to_entity(self, model: MessageModel) -> Message:
+        """モデルをエンティティに変換する
+
+        Args:
+            model: MessageModel インスタンス
+
+        Returns:
+            Message エンティティ
+        """
+
+    def _to_model(self, entity: Message) -> MessageModel:
+        """エンティティをモデルに変換する
+
+        Args:
+            entity: Message エンティティ
+
+        Returns:
+            MessageModel インスタンス
+        """
+```
+
+---
+
+## 実装の詳細
+
+### Upsert の実装
+
+SQLite では `INSERT ... ON CONFLICT ... DO UPDATE` を使用:
+
+```python
+def save(self, message: Message) -> None:
+    with self._session_factory() as session:
+        # 既存レコードを検索
+        existing = session.exec(
+            select(MessageModel).where(
+                MessageModel.message_id == message.id,
+                MessageModel.channel_id == message.channel.id,
+            )
+        ).first()
+
+        if existing:
+            # 更新
+            existing.text = message.text
+            existing.mentions = json.dumps(message.mentions)
+            # ... その他のフィールド
+            session.add(existing)
+        else:
+            # 新規作成
+            model = self._to_model(message)
+            session.add(model)
+
+        session.commit()
+```
+
+### エンティティ変換
+
+```python
+def _to_entity(self, model: MessageModel) -> Message:
+    user = User(
+        id=model.user_id,
+        name=model.user_name,
+        is_bot=model.user_is_bot,
+    )
+    channel = Channel(
+        id=model.channel_id,
+        name="",  # 名前は永続化しない
+    )
+    mentions = json.loads(model.mentions) if model.mentions else []
+
+    return Message(
+        id=model.message_id,
+        channel=channel,
+        user=user,
+        text=model.text,
+        timestamp=model.timestamp,
+        thread_ts=model.thread_ts,
+        mentions=mentions,
+    )
+
+
+def _to_model(self, entity: Message) -> MessageModel:
+    return MessageModel(
+        message_id=entity.id,
+        channel_id=entity.channel.id,
+        user_id=entity.user.id,
+        user_name=entity.user.name,
+        user_is_bot=entity.user.is_bot,
+        text=entity.text,
+        timestamp=entity.timestamp,
+        thread_ts=entity.thread_ts,
+        mentions=json.dumps(entity.mentions),
+    )
+```
+
+---
+
+## テストケース
+
+### test_message_repository.py
+
+#### save
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 新規保存 | 新規メッセージ | データベースに保存される |
+| 更新 | 既存メッセージ（同一 ID） | データが更新される |
+| 複数保存 | 異なるメッセージを連続保存 | すべて保存される |
+
+#### find_by_channel
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 複数メッセージ | チャンネルに5件 | 新しい順で取得 |
+| limit 指定 | 5件中3件取得 | 3件のみ返る |
+| スレッド除外 | スレッド内メッセージあり | スレッドは含まれない |
+| 空チャンネル | メッセージなし | 空リストが返る |
+| 別チャンネル | 他チャンネルのメッセージ | 含まれない |
+
+#### find_by_thread
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| スレッドメッセージ | スレッドに3件 | 新しい順で取得 |
+| limit 指定 | 5件中2件取得 | 2件のみ返る |
+| 別スレッド | 他スレッドのメッセージ | 含まれない |
+| 空スレッド | メッセージなし | 空リストが返る |
+
+#### find_by_id
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 存在する ID | 有効な message_id | Message が返る |
+| 存在しない ID | 無効な message_id | None が返る |
+| 別チャンネル | 同じ ID だが別チャンネル | None が返る |
+
+#### 変換テスト
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| モデル→エンティティ | MessageModel | 正しい Message |
+| エンティティ→モデル | Message | 正しい MessageModel |
+| メンションあり | mentions: ["U1", "U2"] | 正しく変換 |
+| メンションなし | mentions: [] | 空リストで変換 |
+
+---
+
+## テストフィクスチャ
+
+### インメモリデータベース
+
+```python
+@pytest.fixture
+def session_factory():
+    """インメモリ SQLite のセッションファクトリ"""
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    def factory():
+        return Session(engine)
+
+    return factory
+
+
+@pytest.fixture
+def repository(session_factory):
+    """テスト用リポジトリ"""
+    return SQLiteMessageRepository(session_factory)
+```
+
+### テストデータファクトリ
+
+```python
+def create_test_message(
+    id: str = "1234567890.123456",
+    channel_id: str = "C123456",
+    user_id: str = "U123456",
+    user_name: str = "testuser",
+    text: str = "Hello, world!",
+    thread_ts: str | None = None,
+    mentions: list[str] | None = None,
+) -> Message:
+    """テスト用 Message を生成"""
+    return Message(
+        id=id,
+        channel=Channel(id=channel_id, name="general"),
+        user=User(id=user_id, name=user_name, is_bot=False),
+        text=text,
+        timestamp=datetime.now(timezone.utc),
+        thread_ts=thread_ts,
+        mentions=mentions or [],
+    )
+```
+
+---
+
+## 設計上の考慮事項
+
+### チャンネル名の扱い
+
+- チャンネル名は永続化しない
+- 取得時は空文字列を設定
+- チャンネル名が必要な場合は Slack API から再取得
+
+### タイムゾーン
+
+- すべて UTC で保存・取得
+- 表示時にローカルタイムゾーンに変換（Presentation層の責務）
+
+### トランザクション
+
+- 各操作は独立したトランザクション
+- セッションファクトリパターンで柔軟に管理
+
+---
+
+## 完了基準
+
+- [ ] SQLiteMessageRepository が実装されている
+- [ ] save で新規保存・更新が正しく動作する
+- [ ] find_by_channel でスレッド外メッセージのみ取得できる
+- [ ] find_by_thread で指定スレッドのメッセージを取得できる
+- [ ] find_by_id で単一メッセージを取得できる
+- [ ] エンティティとモデルの相互変換ができる
+- [ ] 全テストケースが通過する

--- a/spec/phase-2/03-slack-history.md
+++ b/spec/phase-2/03-slack-history.md
@@ -1,0 +1,390 @@
+# 03: Slack履歴取得
+
+## 目的
+
+Slack API を使ってチャンネル/スレッドの履歴を取得する機能を実装する。
+
+---
+
+## 実装するファイル
+
+| ファイル | 説明 |
+|---------|------|
+| `src/myao2/domain/services/protocols.py` | ConversationHistoryService Protocol 追加（修正） |
+| `src/myao2/infrastructure/slack/history.py` | SlackConversationHistoryService |
+| `tests/infrastructure/slack/test_history.py` | 履歴取得のテスト |
+
+---
+
+## Slack API
+
+### 使用する API
+
+| API | 用途 |
+|-----|------|
+| `conversations.history` | チャンネルのメッセージ履歴を取得 |
+| `conversations.replies` | スレッドのメッセージ履歴を取得 |
+| `users.info` | ユーザー情報を取得（既存の event_adapter と共有） |
+
+### 必要なスコープ
+
+- `channels:history` - パブリックチャンネルの履歴
+- `groups:history` - プライベートチャンネルの履歴（必要に応じて）
+- `users:read` - ユーザー情報（Phase 1 で設定済み）
+
+---
+
+## インターフェース設計
+
+### `src/myao2/domain/services/protocols.py`（修正）
+
+#### ConversationHistoryService Protocol 追加
+
+```
+class ConversationHistoryService(Protocol):
+    """会話履歴取得の抽象インターフェース
+
+    プラットフォーム非依存の会話履歴取得を定義する。
+    """
+
+    def fetch_thread_history(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        limit: int = 20,
+    ) -> list[Message]:
+        """スレッドの履歴を取得する
+
+        Args:
+            channel_id: チャンネル ID
+            thread_ts: スレッドの親タイムスタンプ
+            limit: 取得する最大件数
+
+        Returns:
+            メッセージリスト（古い順）
+        """
+        ...
+
+    def fetch_channel_history(
+        self,
+        channel_id: str,
+        limit: int = 20,
+    ) -> list[Message]:
+        """チャンネルの履歴を取得する
+
+        Args:
+            channel_id: チャンネル ID
+            limit: 取得する最大件数
+
+        Returns:
+            メッセージリスト（古い順）
+        """
+        ...
+```
+
+### `src/myao2/infrastructure/slack/history.py`
+
+#### SlackConversationHistoryService
+
+```
+class SlackConversationHistoryService:
+    """Slack 版 ConversationHistoryService 実装
+
+    Slack API を使って会話履歴を取得する。
+    """
+
+    def __init__(self, client: WebClient) -> None:
+        """初期化
+
+        Args:
+            client: Slack WebClient
+        """
+
+    def fetch_thread_history(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        limit: int = 20,
+    ) -> list[Message]:
+        """スレッドの履歴を取得する
+
+        conversations.replies API を使用。
+        親メッセージを含む全メッセージを取得。
+
+        Args:
+            channel_id: チャンネル ID
+            thread_ts: スレッドの親タイムスタンプ
+            limit: 取得する最大件数
+
+        Returns:
+            メッセージリスト（古い順）
+        """
+
+    def fetch_channel_history(
+        self,
+        channel_id: str,
+        limit: int = 20,
+    ) -> list[Message]:
+        """チャンネルの履歴を取得する
+
+        conversations.history API を使用。
+
+        Args:
+            channel_id: チャンネル ID
+            limit: 取得する最大件数
+
+        Returns:
+            メッセージリスト（古い順）
+        """
+
+    def _to_message(
+        self,
+        msg: dict,
+        channel_id: str,
+    ) -> Message:
+        """Slack API レスポンスを Message エンティティに変換
+
+        Args:
+            msg: Slack API のメッセージオブジェクト
+            channel_id: チャンネル ID
+
+        Returns:
+            Message エンティティ
+        """
+
+    def _get_user_info(self, user_id: str) -> User:
+        """ユーザー情報を取得する
+
+        Args:
+            user_id: ユーザー ID
+
+        Returns:
+            User エンティティ
+        """
+
+    def _extract_mentions(self, text: str) -> list[str]:
+        """テキストからメンションを抽出する
+
+        Args:
+            text: メッセージテキスト
+
+        Returns:
+            メンションされたユーザー ID のリスト
+        """
+```
+
+---
+
+## 実装の詳細
+
+### conversations.replies の呼び出し
+
+```python
+def fetch_thread_history(
+    self,
+    channel_id: str,
+    thread_ts: str,
+    limit: int = 20,
+) -> list[Message]:
+    response = self._client.conversations_replies(
+        channel=channel_id,
+        ts=thread_ts,
+        limit=limit,
+    )
+
+    messages = []
+    for msg in response.get("messages", []):
+        # bot_message や message_changed などのサブタイプは除外
+        if msg.get("subtype") in ["bot_message", "message_changed", "message_deleted"]:
+            continue
+        messages.append(self._to_message(msg, channel_id))
+
+    return messages  # すでに古い順
+```
+
+### conversations.history の呼び出し
+
+```python
+def fetch_channel_history(
+    self,
+    channel_id: str,
+    limit: int = 20,
+) -> list[Message]:
+    response = self._client.conversations_history(
+        channel=channel_id,
+        limit=limit,
+    )
+
+    messages = []
+    for msg in response.get("messages", []):
+        if msg.get("subtype") in ["bot_message", "message_changed", "message_deleted"]:
+            continue
+        messages.append(self._to_message(msg, channel_id))
+
+    # API は新しい順で返すので、古い順に並び替え
+    return list(reversed(messages))
+```
+
+### メッセージ変換
+
+```python
+def _to_message(self, msg: dict, channel_id: str) -> Message:
+    user_id = msg.get("user", "")
+    user = self._get_user_info(user_id) if user_id else User(
+        id="",
+        name="Unknown",
+        is_bot=True,
+    )
+
+    # タイムスタンプ変換（Slack の ts は Unix timestamp 文字列）
+    ts = float(msg["ts"])
+    timestamp = datetime.fromtimestamp(ts, tz=timezone.utc)
+
+    return Message(
+        id=msg["ts"],
+        channel=Channel(id=channel_id, name=""),
+        user=user,
+        text=msg.get("text", ""),
+        timestamp=timestamp,
+        thread_ts=msg.get("thread_ts"),
+        mentions=self._extract_mentions(msg.get("text", "")),
+    )
+```
+
+---
+
+## テストケース
+
+### test_history.py
+
+#### fetch_thread_history
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 正常取得 | スレッドに3件 | 3件のメッセージ（古い順） |
+| 空スレッド | メッセージなし | 空リスト |
+| limit 指定 | 5件中2件 | 2件のみ返る |
+| サブタイプ除外 | bot_message 含む | 通常メッセージのみ |
+
+#### fetch_channel_history
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 正常取得 | チャンネルに5件 | 5件のメッセージ（古い順） |
+| 空チャンネル | メッセージなし | 空リスト |
+| limit 指定 | 10件中3件 | 3件のみ返る |
+| サブタイプ除外 | message_changed 含む | 通常メッセージのみ |
+
+#### _to_message
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 通常メッセージ | 標準的なメッセージ | 正しい Message |
+| スレッドメッセージ | thread_ts あり | thread_ts が設定される |
+| メンションあり | `<@U123>` 含む | mentions に U123 |
+| メンション複数 | `<@U1> <@U2>` | mentions に U1, U2 |
+
+#### エラーハンドリング
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| API エラー | SlackApiError | 例外がそのまま伝播 |
+| チャンネル不在 | channel_not_found | SlackApiError |
+
+---
+
+## テストフィクスチャ
+
+### モック WebClient
+
+```python
+@pytest.fixture
+def mock_client():
+    """モック Slack WebClient"""
+    client = Mock(spec=WebClient)
+    return client
+
+
+@pytest.fixture
+def history_service(mock_client):
+    """テスト用履歴サービス"""
+    return SlackConversationHistoryService(mock_client)
+```
+
+### Slack API レスポンスのモック
+
+```python
+def mock_conversations_replies_response(messages: list[dict]) -> dict:
+    """conversations.replies のモックレスポンス"""
+    return {
+        "ok": True,
+        "messages": messages,
+    }
+
+
+def mock_conversations_history_response(messages: list[dict]) -> dict:
+    """conversations.history のモックレスポンス"""
+    return {
+        "ok": True,
+        "messages": messages,
+    }
+
+
+def create_slack_message(
+    ts: str = "1234567890.123456",
+    user: str = "U123456",
+    text: str = "Hello",
+    thread_ts: str | None = None,
+) -> dict:
+    """Slack API 形式のメッセージを生成"""
+    msg = {
+        "type": "message",
+        "ts": ts,
+        "user": user,
+        "text": text,
+    }
+    if thread_ts:
+        msg["thread_ts"] = thread_ts
+    return msg
+```
+
+---
+
+## 設計上の考慮事項
+
+### 順序の統一
+
+- すべての履歴取得メソッドは **古い順** で返す
+- LLM に渡す会話履歴は時系列順が自然
+- Slack API は新しい順で返すため、チャンネル履歴は reversed() する
+
+### サブタイプの除外
+
+以下のサブタイプは除外する：
+- `bot_message` - ボットからのメッセージ（別途処理）
+- `message_changed` - 編集通知
+- `message_deleted` - 削除通知
+- `channel_join` - 参加通知
+- `channel_leave` - 退出通知
+
+### ユーザー情報の取得
+
+- 既存の SlackEventAdapter と同様のロジックを使用
+- 将来的にはキャッシュを導入予定（Phase 2 ではシンプルさ優先）
+
+### エラーハンドリング
+
+- Slack API エラーはそのまま伝播
+- 呼び出し元（ユースケース）で適切に処理
+
+---
+
+## 完了基準
+
+- [ ] ConversationHistoryService Protocol が定義されている
+- [ ] SlackConversationHistoryService が実装されている
+- [ ] conversations.replies でスレッド履歴が取得できる
+- [ ] conversations.history でチャンネル履歴が取得できる
+- [ ] サブタイプ（bot_message 等）が除外される
+- [ ] 履歴は古い順で返される
+- [ ] 全テストケースが通過する

--- a/spec/phase-2/04-context-response.md
+++ b/spec/phase-2/04-context-response.md
@@ -1,0 +1,299 @@
+# 04: コンテキスト付き応答生成
+
+## 目的
+
+会話履歴を考慮した応答生成を実装する。
+
+---
+
+## 実装するファイル
+
+| ファイル | 説明 |
+|---------|------|
+| `src/myao2/domain/services/protocols.py` | ResponseGenerator 拡張（修正） |
+| `src/myao2/infrastructure/llm/response_generator.py` | 履歴対応（修正） |
+| `tests/infrastructure/llm/test_response_generator.py` | テスト追加（修正） |
+
+---
+
+## インターフェース設計
+
+### `src/myao2/domain/services/protocols.py`（修正）
+
+#### ResponseGenerator Protocol 拡張
+
+```
+class ResponseGenerator(Protocol):
+    """応答生成抽象
+
+    LLM やその他のメカニズムを使って応答を生成する。
+    """
+
+    def generate(
+        self,
+        user_message: str,
+        system_prompt: str,
+        conversation_history: list[Message] | None = None,  # 追加
+    ) -> str:
+        """応答を生成する
+
+        Args:
+            user_message: ユーザーからのメッセージ
+            system_prompt: システムプロンプト
+            conversation_history: 会話履歴（オプション）
+
+        Returns:
+            生成された応答テキスト
+        """
+        ...
+```
+
+### `src/myao2/infrastructure/llm/response_generator.py`（修正）
+
+#### LiteLLMResponseGenerator 修正
+
+```
+class LiteLLMResponseGenerator:
+    """LiteLLM を使った ResponseGenerator 実装
+
+    会話履歴を含めた応答生成をサポートする。
+    """
+
+    def __init__(self, client: LLMClient) -> None:
+        """初期化
+
+        Args:
+            client: LLMClient インスタンス
+        """
+
+    def generate(
+        self,
+        user_message: str,
+        system_prompt: str,
+        conversation_history: list[Message] | None = None,
+    ) -> str:
+        """応答を生成する
+
+        会話履歴がある場合は、LLM のメッセージリストに含める。
+
+        Args:
+            user_message: ユーザーからのメッセージ
+            system_prompt: システムプロンプト
+            conversation_history: 会話履歴（オプション）
+
+        Returns:
+            生成された応答テキスト
+
+        Raises:
+            LLMError: 応答生成に失敗した場合
+        """
+
+    def _build_messages(
+        self,
+        user_message: str,
+        system_prompt: str,
+        conversation_history: list[Message] | None,
+    ) -> list[dict[str, str]]:
+        """LLM に渡すメッセージリストを構築する
+
+        Args:
+            user_message: ユーザーからのメッセージ
+            system_prompt: システムプロンプト
+            conversation_history: 会話履歴
+
+        Returns:
+            OpenAI 形式のメッセージリスト
+        """
+```
+
+---
+
+## 実装の詳細
+
+### メッセージ構築ロジック
+
+```python
+def _build_messages(
+    self,
+    user_message: str,
+    system_prompt: str,
+    conversation_history: list[Message] | None,
+) -> list[dict[str, str]]:
+    messages = [{"role": "system", "content": system_prompt}]
+
+    # 会話履歴を追加（古い順で渡される前提）
+    if conversation_history:
+        for msg in conversation_history:
+            # ボットのメッセージは assistant、それ以外は user
+            role = "assistant" if msg.user.is_bot else "user"
+            messages.append({
+                "role": role,
+                "content": msg.text,
+            })
+
+    # 現在のユーザーメッセージを追加
+    messages.append({"role": "user", "content": user_message})
+
+    return messages
+```
+
+### generate メソッド
+
+```python
+def generate(
+    self,
+    user_message: str,
+    system_prompt: str,
+    conversation_history: list[Message] | None = None,
+) -> str:
+    messages = self._build_messages(
+        user_message,
+        system_prompt,
+        conversation_history,
+    )
+    return self._client.complete(messages)
+```
+
+### LLM メッセージ形式の例
+
+会話履歴がある場合：
+
+```python
+messages = [
+    {"role": "system", "content": "あなたは友達のように振る舞うチャットボットです。"},
+    # 会話履歴（古い順）
+    {"role": "user", "content": "こんにちは！"},
+    {"role": "assistant", "content": "こんにちは！何かお手伝いできることはありますか？"},
+    {"role": "user", "content": "今日の調子はどう？"},
+    {"role": "assistant", "content": "元気ですよ！ありがとう。"},
+    # 現在のメッセージ
+    {"role": "user", "content": "@myao 何か面白い話ある？"},
+]
+```
+
+会話履歴がない場合（Phase 1 互換）：
+
+```python
+messages = [
+    {"role": "system", "content": "あなたは友達のように振る舞うチャットボットです。"},
+    {"role": "user", "content": "@myao こんにちは"},
+]
+```
+
+---
+
+## テストケース
+
+### test_response_generator.py（追加）
+
+#### 履歴なし（後方互換性）
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 履歴なし | conversation_history=None | 従来通り動作 |
+| 空履歴 | conversation_history=[] | 従来通り動作 |
+
+#### 履歴あり
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 単一履歴 | 1件の履歴 | messages に履歴が含まれる |
+| 複数履歴 | 3件の履歴 | 古い順で messages に追加 |
+
+#### ロール判定
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| ユーザーメッセージ | is_bot=False | role="user" |
+| ボットメッセージ | is_bot=True | role="assistant" |
+| 混在 | ユーザーとボット | 正しく role が設定される |
+
+#### _build_messages
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 順序確認 | system → 履歴 → user | 正しい順序 |
+| system 常に先頭 | 履歴あり/なし | system が最初 |
+| user 常に末尾 | 履歴あり/なし | 現在のメッセージが最後 |
+
+---
+
+## テストフィクスチャ
+
+### テスト用メッセージ生成
+
+```python
+def create_history_message(
+    text: str,
+    is_bot: bool = False,
+    user_name: str = "testuser",
+) -> Message:
+    """会話履歴用のテストメッセージを生成"""
+    return Message(
+        id="1234567890.123456",
+        channel=Channel(id="C123", name="general"),
+        user=User(
+            id="U123" if not is_bot else "B123",
+            name=user_name if not is_bot else "myao",
+            is_bot=is_bot,
+        ),
+        text=text,
+        timestamp=datetime.now(timezone.utc),
+        thread_ts=None,
+        mentions=[],
+    )
+```
+
+### モック LLMClient
+
+```python
+@pytest.fixture
+def mock_client():
+    """モック LLMClient"""
+    client = Mock(spec=LLMClient)
+    client.complete.return_value = "Generated response"
+    return client
+
+
+@pytest.fixture
+def generator(mock_client):
+    """テスト用ジェネレータ"""
+    return LiteLLMResponseGenerator(mock_client)
+```
+
+---
+
+## 設計上の考慮事項
+
+### 後方互換性
+
+- `conversation_history` はオプショナル引数（デフォルト: None）
+- 既存の呼び出しはそのまま動作
+- テストも既存のものは変更不要
+
+### ロール判定のシンプルさ
+
+- `is_bot` のみで判定（シンプル）
+- 将来的にはユーザー種別（human, bot, system）を追加可能
+
+### メッセージ順序
+
+- 会話履歴は古い順で渡される前提
+- 呼び出し元（ユースケース）が順序を保証
+
+### メンションの扱い
+
+- メッセージテキストにはメンション（`<@U123>`）がそのまま含まれる
+- LLM がメンションを理解できるよう、Phase 2 では特別な処理はしない
+- 将来的にはメンションを名前に変換する処理を追加可能
+
+---
+
+## 完了基準
+
+- [ ] ResponseGenerator Protocol に conversation_history が追加されている
+- [ ] LiteLLMResponseGenerator が履歴を扱える
+- [ ] 履歴なしでも従来通り動作する（後方互換性）
+- [ ] ボットメッセージは role="assistant" で設定される
+- [ ] メッセージ順序が正しい（system → 履歴 → user）
+- [ ] 全テストケースが通過する

--- a/spec/phase-2/05-usecase-integration.md
+++ b/spec/phase-2/05-usecase-integration.md
@@ -1,0 +1,380 @@
+# 05: ユースケース統合
+
+## 目的
+
+全コンポーネントを統合し、コンテキスト管理機能を完成させる。
+
+---
+
+## 実装するファイル
+
+| ファイル | 説明 |
+|---------|------|
+| `src/myao2/application/use_cases/reply_to_mention.py` | ユースケース修正 |
+| `src/myao2/__main__.py` | エントリポイント修正 |
+| `tests/application/use_cases/test_reply_to_mention.py` | テスト追加 |
+
+---
+
+## 依存関係
+
+- タスク 02（メッセージリポジトリ実装）
+- タスク 03（Slack履歴取得）
+- タスク 04（コンテキスト付き応答生成）
+
+---
+
+## インターフェース設計
+
+### `src/myao2/application/use_cases/reply_to_mention.py`（修正）
+
+#### ReplyToMentionUseCase
+
+```
+class ReplyToMentionUseCase:
+    """メンションへの応答ユースケース
+
+    ボットがメンションされた際に、会話履歴を考慮した応答を生成する。
+    """
+
+    def __init__(
+        self,
+        messaging_service: MessagingService,
+        response_generator: ResponseGenerator,
+        message_repository: MessageRepository,  # 追加
+        conversation_history_service: ConversationHistoryService,  # 追加
+        persona: PersonaConfig,
+        bot_user_id: str,
+    ) -> None:
+        """初期化
+
+        Args:
+            messaging_service: メッセージ送信サービス
+            response_generator: 応答生成サービス
+            message_repository: メッセージリポジトリ
+            conversation_history_service: 会話履歴取得サービス
+            persona: ペルソナ設定
+            bot_user_id: ボットのユーザー ID
+        """
+
+    def execute(self, message: Message) -> None:
+        """ユースケースを実行する
+
+        処理フロー:
+        1. ボット自身のメッセージは無視
+        2. メンションがなければ無視
+        3. 受信メッセージを保存
+        4. 会話履歴を取得（スレッド or チャンネル）
+        5. コンテキスト付きで応答を生成
+        6. 応答を送信
+        7. 応答メッセージを保存
+
+        Args:
+            message: 受信したメッセージ
+        """
+
+    def _get_conversation_history(self, message: Message) -> list[Message]:
+        """会話履歴を取得する
+
+        スレッド内の場合はスレッド履歴を、
+        チャンネル直下の場合はチャンネル履歴を取得する。
+
+        Args:
+            message: 受信したメッセージ
+
+        Returns:
+            会話履歴（古い順）
+        """
+
+    def _create_bot_message(
+        self,
+        response_text: str,
+        original_message: Message,
+    ) -> Message:
+        """ボットの応答メッセージを作成する
+
+        Args:
+            response_text: 応答テキスト
+            original_message: 元のメッセージ
+
+        Returns:
+            ボットの応答 Message
+        """
+```
+
+---
+
+## 実装の詳細
+
+### execute メソッド
+
+```python
+def execute(self, message: Message) -> None:
+    # 1. ボット自身のメッセージは無視
+    if message.user.id == self._bot_user_id:
+        return
+
+    # 2. メンションがなければ無視
+    if not message.mentions_user(self._bot_user_id):
+        return
+
+    # 3. 受信メッセージを保存
+    self._message_repository.save(message)
+
+    # 4. 会話履歴を取得
+    conversation_history = self._get_conversation_history(message)
+
+    # 5. コンテキスト付きで応答を生成
+    response_text = self._response_generator.generate(
+        user_message=message.text,
+        system_prompt=self._persona.system_prompt,
+        conversation_history=conversation_history,
+    )
+
+    # 6. 応答を送信
+    self._messaging_service.send_message(
+        channel_id=message.channel.id,
+        text=response_text,
+        thread_ts=message.thread_ts,
+    )
+
+    # 7. 応答メッセージを保存
+    bot_message = self._create_bot_message(response_text, message)
+    self._message_repository.save(bot_message)
+```
+
+### _get_conversation_history メソッド
+
+```python
+def _get_conversation_history(self, message: Message) -> list[Message]:
+    if message.is_in_thread():
+        # スレッド内の場合はスレッド履歴を取得
+        return self._conversation_history_service.fetch_thread_history(
+            channel_id=message.channel.id,
+            thread_ts=message.thread_ts,
+            limit=20,
+        )
+    else:
+        # チャンネル直下の場合はチャンネル履歴を取得
+        return self._conversation_history_service.fetch_channel_history(
+            channel_id=message.channel.id,
+            limit=20,
+        )
+```
+
+### _create_bot_message メソッド
+
+```python
+def _create_bot_message(
+    self,
+    response_text: str,
+    original_message: Message,
+) -> Message:
+    return Message(
+        id=str(datetime.now(timezone.utc).timestamp()),  # 仮の ID
+        channel=original_message.channel,
+        user=User(
+            id=self._bot_user_id,
+            name=self._persona.name,
+            is_bot=True,
+        ),
+        text=response_text,
+        timestamp=datetime.now(timezone.utc),
+        thread_ts=original_message.thread_ts,
+        mentions=[],
+    )
+```
+
+---
+
+## エントリポイント修正
+
+### `src/myao2/__main__.py`
+
+```python
+def main() -> None:
+    # 設定読み込み
+    config = load_config("config.yaml")
+
+    # Slack アプリ初期化
+    app = App(
+        token=config.slack.bot_token,
+        # ...
+    )
+    bot_user_id = app.client.auth_test()["user_id"]
+
+    # データベース初期化
+    db_manager = DatabaseManager(config.memory.database_path)
+    db_manager.create_tables()
+
+    # 依存性の構築
+    messaging_service = SlackMessagingService(app.client)
+    event_adapter = SlackEventAdapter(app.client)
+    llm_client = LLMClient(config.llm["default"])
+    response_generator = LiteLLMResponseGenerator(llm_client)
+    message_repository = SQLiteMessageRepository(db_manager.get_session)
+    conversation_history_service = SlackConversationHistoryService(app.client)
+
+    # ユースケース初期化
+    reply_use_case = ReplyToMentionUseCase(
+        messaging_service=messaging_service,
+        response_generator=response_generator,
+        message_repository=message_repository,
+        conversation_history_service=conversation_history_service,
+        persona=config.persona,
+        bot_user_id=bot_user_id,
+    )
+
+    # ハンドラ登録
+    register_handlers(app, reply_use_case, event_adapter, bot_user_id)
+
+    # 起動
+    runner = SlackAppRunner(app, config.slack.app_token)
+    runner.start()
+```
+
+---
+
+## テストケース
+
+### test_reply_to_mention.py（追加）
+
+#### メッセージ保存
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 受信メッセージ保存 | メンション受信 | repository.save が呼ばれる |
+| 応答メッセージ保存 | 応答送信後 | 2回目の save が呼ばれる |
+
+#### 会話履歴取得
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| スレッド内 | thread_ts あり | fetch_thread_history が呼ばれる |
+| チャンネル直下 | thread_ts なし | fetch_channel_history が呼ばれる |
+
+#### コンテキスト付き生成
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| 履歴渡し | 履歴3件 | generate に履歴が渡される |
+| 履歴空 | 履歴なし | generate に空リストが渡される |
+
+#### 既存テストの維持
+
+| テスト | シナリオ | 期待結果 |
+|--------|---------|---------|
+| メンション時の応答 | メンションあり | メッセージが送信される |
+| スレッド返信 | スレッド内メンション | スレッドに返信 |
+| メンションなし | メンションなし | 何もしない |
+| ボット自身 | ボットのメッセージ | 何もしない |
+
+---
+
+## テストフィクスチャ
+
+### モックオブジェクト
+
+```python
+@pytest.fixture
+def mock_repository():
+    """モック MessageRepository"""
+    return Mock(spec=["save", "find_by_channel", "find_by_thread", "find_by_id"])
+
+
+@pytest.fixture
+def mock_history_service():
+    """モック ConversationHistoryService"""
+    service = Mock(spec=["fetch_thread_history", "fetch_channel_history"])
+    service.fetch_thread_history.return_value = []
+    service.fetch_channel_history.return_value = []
+    return service
+
+
+@pytest.fixture
+def use_case(
+    mock_messaging_service,
+    mock_response_generator,
+    mock_repository,
+    mock_history_service,
+    persona_config,
+):
+    """テスト用ユースケース"""
+    return ReplyToMentionUseCase(
+        messaging_service=mock_messaging_service,
+        response_generator=mock_response_generator,
+        message_repository=mock_repository,
+        conversation_history_service=mock_history_service,
+        persona=persona_config,
+        bot_user_id="B123456",
+    )
+```
+
+---
+
+## シーケンス図
+
+### メンション応答フロー
+
+```
+User                Slack           UseCase         Repository      HistoryService    LLM
+ |                   |                |                |                |              |
+ |-- @myao hello --->|                |                |                |              |
+ |                   |-- message ---->|                |                |              |
+ |                   |                |-- save() ----->|                |              |
+ |                   |                |<-- ok ---------|                |              |
+ |                   |                |                |                |              |
+ |                   |                |-- fetch_*() ------------------>|              |
+ |                   |                |<-- history --------------------|              |
+ |                   |                |                |                |              |
+ |                   |                |-- generate(history) ----------------------->|
+ |                   |                |<-- response --------------------------------|
+ |                   |                |                |                |              |
+ |                   |<-- send() -----|                |                |              |
+ |<-- response ------|                |                |                |              |
+ |                   |                |                |                |              |
+ |                   |                |-- save(bot_msg)|                |              |
+ |                   |                |<-- ok ---------|                |              |
+```
+
+---
+
+## 設計上の考慮事項
+
+### 応答メッセージの ID
+
+- Slack API からは送信後に ts（メッセージ ID）が返る
+- Phase 2 では仮の ID（現在時刻）を使用
+- 将来的には send_message の戻り値から取得する形に改善可能
+
+### エラーハンドリング
+
+- LLM エラー: ログに記録し、処理を中断
+- Slack API エラー: ログに記録し、処理を中断
+- DB エラー: ログに記録し、応答は試みる
+
+### 履歴の件数
+
+- デフォルト 20 件
+- LLM のコンテキスト長を考慮して調整可能
+- 将来的には設定ファイルで指定可能に
+
+### 既存テストへの影響
+
+- 新しい依存（repository, history_service）はモックで注入
+- 既存のテストシナリオは変更なしで通過すべき
+
+---
+
+## 完了基準
+
+- [ ] ReplyToMentionUseCase が MessageRepository を使用している
+- [ ] ReplyToMentionUseCase が ConversationHistoryService を使用している
+- [ ] 受信メッセージがリポジトリに保存される
+- [ ] 応答メッセージがリポジトリに保存される
+- [ ] スレッド内ではスレッド履歴が使用される
+- [ ] チャンネル直下ではチャンネル履歴が使用される
+- [ ] 履歴付きで応答が生成される
+- [ ] エントリポイントで依存性が正しく注入されている
+- [ ] 既存のテストが引き続き通過する
+- [ ] 新規テストケースが通過する

--- a/spec/phase-2/README.md
+++ b/spec/phase-2/README.md
@@ -1,0 +1,268 @@
+# Phase 2: コンテキスト管理 - 実装手順書
+
+## 目標
+
+会話履歴を考慮した応答を実現する。
+
+## 成果物
+
+会話の流れを理解して応答できるボット
+
+- スレッド/チャンネルの会話履歴を踏まえた応答
+- SQLite による会話履歴の永続化
+- 過去のやり取りを覚えた自然な会話
+
+---
+
+## 前提条件
+
+### Phase 1 完了
+
+Phase 1 で以下が実装済みであること：
+
+- クリーンアーキテクチャの基本構造
+- Slack 連携（Socket Mode、メンション検出）
+- LLM 応答（LiteLLM）
+- エンティティ: User, Channel, Message
+- Protocol: MessagingService, ResponseGenerator
+- ユースケース: ReplyToMentionUseCase
+
+### 追加のSlackスコープ
+
+Phase 1 に加えて以下のスコープが必要：
+
+- `channels:history` - チャンネル履歴の読み取り（Phase 1 で設定済み）
+- `groups:history` - プライベートチャンネル履歴（必要に応じて）
+
+### 依存ライブラリ追加
+
+```toml
+# pyproject.toml
+dependencies = [
+    # ... 既存の依存関係
+    "sqlmodel>=0.0.24",  # 追加
+]
+```
+
+---
+
+## タスク一覧
+
+| # | タスク | 詳細設計書 | 依存 |
+|---|--------|-----------|------|
+| 01 | SQLite永続化基盤 | [01-sqlite-persistence.md](./01-sqlite-persistence.md) | - |
+| 02 | メッセージリポジトリ実装 | [02-message-repository.md](./02-message-repository.md) | 01 |
+| 03 | Slack履歴取得 | [03-slack-history.md](./03-slack-history.md) | - |
+| 04 | コンテキスト付き応答生成 | [04-context-response.md](./04-context-response.md) | - |
+| 05 | ユースケース統合 | [05-usecase-integration.md](./05-usecase-integration.md) | 02, 03, 04 |
+
+---
+
+## 実装順序
+
+```
+[01] SQLite永続化基盤    [03] Slack履歴取得    [04] コンテキスト付き応答
+        ↓                     │                      │
+[02] メッセージ              │                      │
+    リポジトリ実装            │                      │
+        └──────────────┬──────┴──────────────────────┘
+                       ↓
+            [05] ユースケース統合
+                       ↓
+                  動作確認
+```
+
+タスク 01, 03, 04 は並行して実装可能。
+
+---
+
+## タスク概要
+
+### 01: SQLite永続化基盤
+
+SQLModel を使ったデータベース基盤を構築する。
+
+- MessageModel テーブル定義
+- DatabaseManager（エンジン生成、テーブル作成）
+- MessageRepository Protocol 定義
+- MemoryConfig 追加
+
+### 02: メッセージリポジトリ実装
+
+MessageRepository の SQLite 実装を作成する。
+
+- SQLiteMessageRepository 実装
+- CRUD 操作（save, find_by_channel, find_by_thread, find_by_id）
+- エンティティとモデルの相互変換
+
+### 03: Slack履歴取得
+
+Slack API を使ってチャンネル/スレッドの履歴を取得する。
+
+- ConversationHistoryService Protocol 定義
+- SlackConversationHistoryService 実装
+- conversations.history / conversations.replies の呼び出し
+
+### 04: コンテキスト付き応答生成
+
+会話履歴を考慮した応答生成を実装する。
+
+- ResponseGenerator Protocol の拡張（conversation_history 追加）
+- LiteLLMResponseGenerator の修正
+- 後方互換性の維持
+
+### 05: ユースケース統合
+
+全コンポーネントを統合し、コンテキスト管理機能を完成させる。
+
+- ReplyToMentionUseCase の修正
+- エントリポイント（__main__.py）の更新
+- 受信/応答メッセージの永続化
+
+---
+
+## Phase 2 完了の検証方法
+
+### 自動テスト
+
+```bash
+# 全テストの実行
+uv run pytest
+
+# Linter
+uv run ruff check .
+
+# 型チェック
+uv run ty check
+```
+
+### 手動検証
+
+1. アプリケーションを起動
+
+```bash
+uv run python -m myao2
+```
+
+2. チャンネルで複数回やり取り
+
+```
+あなた: @myao2 こんにちは
+myao2: こんにちは！何かお手伝いできることはありますか？
+
+あなた: @myao2 今日の天気はどうかな
+myao2: [過去の会話を踏まえた応答]
+```
+
+3. スレッドでのやり取りでも同様に確認
+
+4. データベースにデータが保存されていることを確認
+
+```bash
+sqlite3 ./data/memory.db "SELECT * FROM messages LIMIT 5;"
+```
+
+---
+
+## ディレクトリ構造（Phase 2 完了時）
+
+```
+src/myao2/
+├── __init__.py
+├── __main__.py              # エントリポイント（修正）
+├── config/
+│   ├── __init__.py
+│   ├── loader.py
+│   └── models.py            # MemoryConfig 追加
+├── domain/
+│   ├── __init__.py
+│   ├── entities/
+│   │   ├── __init__.py
+│   │   ├── message.py
+│   │   ├── user.py
+│   │   └── channel.py
+│   ├── repositories/        # 新規
+│   │   ├── __init__.py
+│   │   └── message_repository.py
+│   └── services/
+│       ├── __init__.py
+│       └── protocols.py     # ConversationHistoryService 追加
+├── application/
+│   ├── __init__.py
+│   └── use_cases/
+│       ├── __init__.py
+│       └── reply_to_mention.py  # 修正
+├── infrastructure/
+│   ├── __init__.py
+│   ├── slack/
+│   │   ├── __init__.py
+│   │   ├── client.py
+│   │   ├── messaging.py
+│   │   ├── event_adapter.py
+│   │   └── history.py       # 新規
+│   ├── llm/
+│   │   ├── __init__.py
+│   │   ├── client.py
+│   │   ├── exceptions.py
+│   │   └── response_generator.py  # 修正
+│   └── persistence/         # 新規
+│       ├── __init__.py
+│       ├── database.py
+│       ├── models.py
+│       └── message_repository.py
+└── presentation/
+    ├── __init__.py
+    └── slack_handlers.py
+
+tests/
+├── __init__.py
+├── conftest.py
+├── config/
+│   └── test_loader.py
+├── domain/
+│   ├── entities/
+│   │   └── test_message.py
+│   └── repositories/        # 新規
+│       └── test_message_repository.py
+├── application/
+│   └── use_cases/
+│       └── test_reply_to_mention.py  # 修正
+└── infrastructure/
+    ├── slack/
+    │   ├── test_messaging.py
+    │   ├── test_event_adapter.py
+    │   └── test_history.py  # 新規
+    ├── llm/
+    │   ├── test_client.py
+    │   └── test_response_generator.py  # 修正
+    └── persistence/         # 新規
+        ├── test_database.py
+        └── test_message_repository.py
+```
+
+---
+
+## 設計上の考慮事項
+
+### プラットフォーム非依存
+
+- Domain層の Repository Protocol は Slack に依存しない
+- ConversationHistoryService も抽象化
+- 将来 Discord 等に対応する際も Domain/Application 層は変更不要
+
+### 後方互換性
+
+- ResponseGenerator の conversation_history はオプショナル
+- 履歴なしでも従来通り動作
+
+### パフォーマンス
+
+- 履歴取得は limit で件数を制限（デフォルト: 20件）
+- SQLite のインデックスを適切に設定
+- Phase 2 ではキャッシュは実装しない（シンプルさ優先）
+
+### エラーハンドリング
+
+- データベースエラーは適切な例外に変換
+- Slack API エラーはログに記録
+- LLM エラーは既存の例外クラスを使用


### PR DESCRIPTION
## Summary

- Phase 2「コンテキスト管理」の設計書を追加
- Phase 1 と同様の形式で、README + 個別タスク設計書を作成
- 会話履歴を考慮した応答を実現するための詳細設計

## 作成したドキュメント

| ファイル | 内容 |
|---------|------|
| `README.md` | 全体手順書・概要 |
| `01-sqlite-persistence.md` | SQLite永続化基盤（SQLModel、DatabaseManager） |
| `02-message-repository.md` | メッセージリポジトリ実装（CRUD操作） |
| `03-slack-history.md` | Slack履歴取得（conversations.history/replies） |
| `04-context-response.md` | コンテキスト付き応答生成（ResponseGenerator拡張） |
| `05-usecase-integration.md` | ユースケース統合（ReplyToMentionUseCase修正） |

## Phase 2 の目標

- チャンネル/スレッドの履歴取得
- SQLiteによる会話履歴の永続化
- 基本的なコンテキストを使った応答

## 実装順序

```
[01] SQLite基盤    [03] Slack履歴    [04] 応答生成
       ↓               │                │
[02] Repository       │                │
       └──────────────┴────────────────┘
                      ↓
            [05] ユースケース統合
```

## Test plan

- [ ] 設計書の内容を確認
- [ ] Phase 1 の形式と整合性があることを確認
- [ ] requirements.md の Phase 2 要件を満たしていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)