### PR TITLE
Add debug logging for LLM messages with configurable options

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -31,6 +31,17 @@ memory:
   database_path: "./data/memory.db"
   long_term_update_interval_seconds: 3600
 
+# ログ設定（オプショナル）
+logging:
+  level: INFO  # ルートログレベル（DEBUG, INFO, WARNING, ERROR, CRITICAL）
+  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  # LLMに渡すメッセージをINFOレベルで出力（開発時のデバッグ用）
+  debug_llm_messages: false
+  # 個別ロガーのレベル設定
+  loggers:
+    # 例: 特定のモジュールをDEBUGレベルに
+    # myao2.infrastructure.slack: DEBUG
+
 # 外部サービス設定
 external:
   web_search:

--- a/src/myao2/config/__init__.py
+++ b/src/myao2/config/__init__.py
@@ -10,6 +10,7 @@ from myao2.config.loader import (
 from myao2.config.models import (
     Config,
     LLMConfig,
+    LoggingConfig,
     MemoryConfig,
     PersonaConfig,
     SlackConfig,
@@ -21,6 +22,7 @@ __all__ = [
     "ConfigValidationError",
     "EnvironmentVariableError",
     "LLMConfig",
+    "LoggingConfig",
     "MemoryConfig",
     "PersonaConfig",
     "SlackConfig",

--- a/src/myao2/config/loader.py
+++ b/src/myao2/config/loader.py
@@ -10,6 +10,7 @@ import yaml
 from myao2.config.models import (
     Config,
     LLMConfig,
+    LoggingConfig,
     MemoryConfig,
     PersonaConfig,
     SlackConfig,
@@ -163,4 +164,19 @@ def load_config(path: str | Path) -> Config:
         ),
     )
 
-    return Config(slack=slack, llm=llm, persona=persona, memory=memory)
+    # LoggingConfig (optional)
+    logging_config: LoggingConfig | None = None
+    logging_data = data.get("logging")
+    if logging_data:
+        logging_config = LoggingConfig(
+            level=logging_data.get("level", "INFO"),
+            format=logging_data.get(
+                "format", "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            ),
+            loggers=logging_data.get("loggers"),
+            debug_llm_messages=logging_data.get("debug_llm_messages", False),
+        )
+
+    return Config(
+        slack=slack, llm=llm, persona=persona, memory=memory, logging=logging_config
+    )

--- a/src/myao2/config/models.py
+++ b/src/myao2/config/models.py
@@ -37,6 +37,16 @@ class MemoryConfig:
 
 
 @dataclass
+class LoggingConfig:
+    """ログ設定"""
+
+    level: str = "INFO"
+    format: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    loggers: dict[str, str] | None = None
+    debug_llm_messages: bool = False
+
+
+@dataclass
 class Config:
     """アプリケーション設定"""
 
@@ -44,3 +54,4 @@ class Config:
     llm: dict[str, LLMConfig]
     persona: PersonaConfig
     memory: MemoryConfig
+    logging: LoggingConfig | None = None

--- a/src/myao2/infrastructure/llm/response_generator.py
+++ b/src/myao2/infrastructure/llm/response_generator.py
@@ -1,7 +1,11 @@
 """LLM response generator."""
 
+import logging
+
 from myao2.domain.entities import Context, Message
 from myao2.infrastructure.llm.client import LLMClient
+
+logger = logging.getLogger(__name__)
 
 
 class LiteLLMResponseGenerator:
@@ -11,13 +15,20 @@ class LiteLLMResponseGenerator:
     to generate responses with conversation context.
     """
 
-    def __init__(self, client: LLMClient) -> None:
+    def __init__(
+        self,
+        client: LLMClient,
+        *,
+        debug_llm_messages: bool = False,
+    ) -> None:
         """Initialize the generator.
 
         Args:
             client: LLMClient instance.
+            debug_llm_messages: If True, log LLM messages at INFO level.
         """
         self._client = client
+        self._debug_llm_messages = debug_llm_messages
 
     def generate(
         self,
@@ -39,4 +50,35 @@ class LiteLLMResponseGenerator:
             LLMError: If response generation fails.
         """
         messages = context.build_messages_for_llm(user_message)
-        return self._client.complete(messages)
+
+        if self._should_log():
+            self._log_messages(messages)
+
+        response = self._client.complete(messages)
+
+        if self._should_log():
+            self._log_response(response)
+
+        return response
+
+    def _should_log(self) -> bool:
+        """Check if logging should occur."""
+        return self._debug_llm_messages or logger.isEnabledFor(logging.DEBUG)
+
+    def _log_messages(self, messages: list[dict[str, str]]) -> None:
+        """Log LLM request messages."""
+        log_func = logger.info if self._debug_llm_messages else logger.debug
+        log_func("=== LLM Request Messages ===")
+        for i, msg in enumerate(messages):
+            role = msg.get("role", "unknown")
+            content = msg.get("content", "")
+            log_func("[%d] role=%s", i, role)
+            log_func("    content: %s", content)
+        log_func("=== End of Messages ===")
+
+    def _log_response(self, response: str) -> None:
+        """Log LLM response."""
+        log_func = logger.info if self._debug_llm_messages else logger.debug
+        log_func("=== LLM Response ===")
+        log_func("response: %s", response)
+        log_func("=== End of Response ===")


### PR DESCRIPTION
## Summary

- Add debug logging for LLM request/response messages in `LiteLLMResponseGenerator`
- Add `LoggingConfig` for configurable logging settings via `config.yaml`
- Add `debug_llm_messages` flag to output LLM messages at INFO level

## Configuration

```yaml
logging:
  level: INFO
  debug_llm_messages: true  # Output LLM messages at INFO level
  loggers:
    myao2.infrastructure.slack: DEBUG  # Per-logger level
```

## Test plan

- [x] All 123 tests pass
- [x] ruff check passes
- [x] ruff format passes
- [x] ty check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)