### PR TITLE
Fix duplicate user message in LLM context

### DIFF
--- a/src/myao2/domain/entities/context.py
+++ b/src/myao2/domain/entities/context.py
@@ -42,7 +42,8 @@ class Context:
         """Build message list for LLM.
 
         Constructs an OpenAI-compatible message list from conversation history
-        and the current user message.
+        and the current user message. If the current message is already in
+        the conversation history, it will not be duplicated.
 
         Args:
             user_message: Current user message.
@@ -56,7 +57,12 @@ class Context:
         ]
 
         # Add conversation history (already in chronological order)
-        for msg in self.conversation_history:
+        # Skip the last message if it's the same as user_message to avoid duplication
+        history_to_process = self.conversation_history
+        if history_to_process and history_to_process[-1].id == user_message.id:
+            history_to_process = history_to_process[:-1]
+
+        for msg in history_to_process:
             role = "assistant" if msg.user.is_bot else "user"
             messages.append({"role": role, "content": msg.text})
 


### PR DESCRIPTION
## Summary

- Fix duplicate user message when building LLM message list
- Skip last message in conversation history if it matches the current user message ID

## Problem

When `conversation_history` already contains the current user message (fetched from Slack history), `build_messages_for_llm` was adding it again, causing duplication in the LLM request.

## Solution

Check if the last message in `conversation_history` has the same ID as `user_message` and skip it to avoid duplication.

## Test plan

- [x] Added test for duplicate message handling
- [x] All 125 tests pass
- [x] ruff check passes
- [x] ruff format passes
- [x] ty check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)