### PR TITLE
feat(config): Add ResponseConfig for autonomous response settings

### DIFF
--- a/spec/phase-3/01-response-config.md
+++ b/spec/phase-3/01-response-config.md
@@ -94,8 +94,8 @@ class Config:
 
 ## 完了基準
 
-- [ ] ResponseConfig が定義されている
-- [ ] Config に response フィールドが追加されている
-- [ ] loader.py で response セクションが読み込まれる
-- [ ] response セクションがない場合はデフォルト値が使用される
-- [ ] 全テストケースが通過する
+- [x] ResponseConfig が定義されている
+- [x] Config に response フィールドが追加されている
+- [x] loader.py で response セクションが読み込まれる
+- [x] response セクションがない場合はデフォルト値が使用される
+- [x] 全テストケースが通過する

--- a/src/myao2/config/__init__.py
+++ b/src/myao2/config/__init__.py
@@ -13,6 +13,7 @@ from myao2.config.models import (
     LoggingConfig,
     MemoryConfig,
     PersonaConfig,
+    ResponseConfig,
     SlackConfig,
 )
 
@@ -25,6 +26,7 @@ __all__ = [
     "LoggingConfig",
     "MemoryConfig",
     "PersonaConfig",
+    "ResponseConfig",
     "SlackConfig",
     "expand_env_vars",
     "load_config",

--- a/src/myao2/config/loader.py
+++ b/src/myao2/config/loader.py
@@ -13,6 +13,7 @@ from myao2.config.models import (
     LoggingConfig,
     MemoryConfig,
     PersonaConfig,
+    ResponseConfig,
     SlackConfig,
 )
 
@@ -164,6 +165,13 @@ def load_config(path: str | Path) -> Config:
         ),
     )
 
+    # ResponseConfig (optional, defaults used if not present)
+    response_data = data.get("response", {})
+    response = ResponseConfig(
+        check_interval_seconds=response_data.get("check_interval_seconds", 60),
+        min_wait_seconds=response_data.get("min_wait_seconds", 300),
+    )
+
     # LoggingConfig (optional)
     logging_config: LoggingConfig | None = None
     logging_data = data.get("logging")
@@ -178,5 +186,10 @@ def load_config(path: str | Path) -> Config:
         )
 
     return Config(
-        slack=slack, llm=llm, persona=persona, memory=memory, logging=logging_config
+        slack=slack,
+        llm=llm,
+        persona=persona,
+        memory=memory,
+        response=response,
+        logging=logging_config,
     )

--- a/src/myao2/config/models.py
+++ b/src/myao2/config/models.py
@@ -47,6 +47,14 @@ class LoggingConfig:
 
 
 @dataclass
+class ResponseConfig:
+    """自律応答設定"""
+
+    check_interval_seconds: int = 60
+    min_wait_seconds: int = 300
+
+
+@dataclass
 class Config:
     """アプリケーション設定"""
 
@@ -54,4 +62,5 @@ class Config:
     llm: dict[str, LLMConfig]
     persona: PersonaConfig
     memory: MemoryConfig
+    response: ResponseConfig
     logging: LoggingConfig | None = None


### PR DESCRIPTION
## Summary

- Add `ResponseConfig` dataclass with `check_interval_seconds` and `min_wait_seconds` fields
- Add `response` field to `Config` dataclass
- Implement response section loading in `loader.py` (optional with defaults)
- Export `ResponseConfig` from `myao2.config` module

## Related

Implements `spec/phase-3/01-response-config.md`

## Test plan

- [x] `ResponseConfig` default values test
- [x] `ResponseConfig` custom values test
- [x] Load config with response section
- [x] Load config without response section (uses defaults)
- [x] Load config with partial response section
- [x] All 27 tests pass
- [x] ruff check passes
- [x] ty check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)