### PR TITLE
Fix agents.*.system_prompt not being loaded from config

### DIFF
--- a/hack/prompt_tester.py
+++ b/hack/prompt_tester.py
@@ -208,7 +208,10 @@ async def run_generate(
 
     # Create model and generator
     response_model = create_model(config.agents["response"])
-    generator = StrandsResponseGenerator(response_model)
+    generator = StrandsResponseGenerator(
+        response_model,
+        agent_config=config.agents["response"],
+    )
 
     # プロンプト構築
     system_prompt = generator.build_system_prompt(context)
@@ -256,7 +259,10 @@ async def run_judgment(
 
     # Create model and judgment
     judgment_model = create_model(config.agents["judgment"])
-    judgment = StrandsResponseJudgment(judgment_model)
+    judgment = StrandsResponseJudgment(
+        judgment_model,
+        agent_config=config.agents["judgment"],
+    )
 
     # プロンプト構築
     system_prompt = judgment.build_system_prompt(context)
@@ -351,7 +357,11 @@ async def run_summarize(
 
     # Create model and summarizer
     memory_model = create_model(config.agents["memory"])
-    summarizer = StrandsMemorySummarizer(model=memory_model, config=config.memory)
+    summarizer = StrandsMemorySummarizer(
+        model=memory_model,
+        config=config.memory,
+        agent_config=config.agents["memory"],
+    )
 
     # プロンプト構築
     system_prompt = summarizer.build_system_prompt(context, scope, memory_type)

--- a/src/myao2/__main__.py
+++ b/src/myao2/__main__.py
@@ -203,6 +203,7 @@ async def main() -> None:
 
     response_generator = StrandsResponseGenerator(
         response_model,
+        agent_config=config.agents["response"],
         memo_tools_factory=memo_tools_factory,
         web_fetch_tools_factory=web_fetch_tools_factory,
         web_search_tools_factory=web_search_tools_factory,
@@ -243,7 +244,10 @@ async def main() -> None:
     await channel_initializer.sync_channels()
 
     # Initialize autonomous response components
-    response_judgment = StrandsResponseJudgment(judgment_model)
+    response_judgment = StrandsResponseJudgment(
+        judgment_model,
+        agent_config=config.agents["judgment"],
+    )
 
     channel_monitor = DBChannelMonitor(
         message_repository=message_repository,
@@ -277,6 +281,7 @@ async def main() -> None:
     memory_summarizer = StrandsMemorySummarizer(
         model=memory_model,
         config=config.memory,
+        agent_config=config.agents["memory"],
     )
 
     generate_memory_use_case = GenerateMemoryUseCase(

--- a/src/myao2/config/loader.py
+++ b/src/myao2/config/loader.py
@@ -153,6 +153,7 @@ def load_config(path: str | Path) -> Config:
         model_id = _validate_required_field(agent_item, "model_id", f"agents.{key}")
         agents[key] = AgentConfig(
             model_id=model_id,
+            system_prompt=agent_item.get("system_prompt"),
             params=agent_item.get("params", {}),
             client_args=agent_item.get("client_args", {}),
         )


### PR DESCRIPTION
## Summary

- `config.yaml` の `agents.*.system_prompt` が LLM への入力に反映されていなかった問題を修正

## Changes

- `loader.py`: `AgentConfig` 作成時に `system_prompt` フィールドを読み込むよう追加
- `__main__.py`: 各ジェネレータ/ジャッジメント/サマライザー初期化時に `agent_config` を渡すよう修正
- `hack/prompt_tester.py`: 同上
- `tests/config/test_loader.py`: `system_prompt` 読み込みのテストを追加

## Test plan

- [x] `uv run pytest tests/config/test_loader.py` でテストがパスすることを確認
- [x] `uv run hack/prompt_tester.py --channel general --dry-run generate` で `agents.response.system_prompt` の内容が出力に含まれることを確認
- [x] `uv run python -m myao2` 実行時に tracing で system_prompt が含まれていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)